### PR TITLE
Improve worker code display

### DIFF
--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -73,27 +73,72 @@ public class WorkRecordController {
         Sheet sheet = wb.createSheet("records");
         Row head = sheet.createRow(0);
         String[] titles = {"通知单号","产品名称","图号","批次号","工序代码","工时","产量","人员代码","姓名","合格数","工时小计"};
-        for(int i=0;i<titles.length;i++) head.createCell(i).setCellValue(titles[i]);
-        int rowIdx=1;
-        for(WorkRecord r:list){
-            Row row = sheet.createRow(rowIdx++);
-            int c=0;
-            row.createCell(c++).setCellValue(n(r.getNotificationNumber()));
-            row.createCell(c++).setCellValue(n(r.getProductName()));
-            row.createCell(c++).setCellValue(n(r.getDrawingNumber()));
-            row.createCell(c++).setCellValue(n(r.getBatchNumber()));
-            row.createCell(c++).setCellValue(n(r.getProcessCode()));
-            if(r.getHours()!=null) row.createCell(c++).setCellValue(r.getHours()); else row.createCell(c++).setCellValue("");
-            if(r.getPlanQty()!=null) row.createCell(c++).setCellValue(r.getPlanQty()); else row.createCell(c++).setCellValue("");
-            row.createCell(c++).setCellValue(n(r.getWorkerCodes()));
-            row.createCell(c++).setCellValue(n(r.getWorkerNames()));
-            if(r.getQualifiedQty()!=null) row.createCell(c++).setCellValue(r.getQualifiedQty()); else row.createCell(c++).setCellValue("");
-            if(r.getHourSubtotal()!=null) row.createCell(c++).setCellValue(r.getHourSubtotal()); else row.createCell(c++).setCellValue("");
+        for (int i = 0; i < titles.length; i++) head.createCell(i).setCellValue(titles[i]);
+
+        int rowIdx = 1;
+        for (WorkRecord r : list) {
+            java.util.List<String> codes = splitWorkers(r.getWorkerCodes());
+            java.util.List<String> names = splitNames(r.getWorkerNames());
+            java.util.List<Double> qtys = parseQtys(r.getWorkerQtys());
+            int max = Math.max(1, Math.max(Math.max(codes.size(), names.size()), qtys.size()));
+
+            for (int i = 0; i < max; i++) {
+                Row row = sheet.createRow(rowIdx++);
+                int c = 0;
+                row.createCell(c++).setCellValue(n(r.getNotificationNumber()));
+                row.createCell(c++).setCellValue(n(r.getProductName()));
+                row.createCell(c++).setCellValue(n(r.getDrawingNumber()));
+                row.createCell(c++).setCellValue(n(r.getBatchNumber()));
+                row.createCell(c++).setCellValue(n(r.getProcessCode()));
+                if (r.getHours() != null) row.createCell(c++).setCellValue(r.getHours()); else row.createCell(c++).setCellValue("");
+                if (r.getPlanQty() != null) row.createCell(c++).setCellValue(r.getPlanQty()); else row.createCell(c++).setCellValue("");
+                row.createCell(c++).setCellValue(i < codes.size() ? n(codes.get(i)) : "");
+                row.createCell(c++).setCellValue(i < names.size() ? n(names.get(i)) : "");
+                Double q = i < qtys.size() ? qtys.get(i) : null;
+                if (q != null) row.createCell(c++).setCellValue(q);
+                else if (i == 0 && r.getQualifiedQty() != null && max == 1) row.createCell(c++).setCellValue(r.getQualifiedQty());
+                else row.createCell(c++).setCellValue("");
+                Double hs = null;
+                if (q != null && r.getHours() != null) hs = q * r.getHours();
+                if (hs != null) row.createCell(c++).setCellValue(hs);
+                else if (i == 0 && r.getHourSubtotal() != null && max == 1) row.createCell(c++).setCellValue(r.getHourSubtotal());
+                else row.createCell(c++).setCellValue("");
+            }
         }
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition","attachment; filename=records.xlsx");
+        response.setHeader("Content-Disposition", "attachment; filename=records.xlsx");
         wb.write(response.getOutputStream());
         wb.close();
+    }
+
+    private java.util.List<String> splitWorkers(String codes) {
+        if (codes == null || codes.trim().isEmpty()) return java.util.Collections.emptyList();
+        String[] arr = codes.split("[,\u3001\\s]+");
+        java.util.List<String> list = new java.util.ArrayList<>();
+        for (String s : arr) if (!s.trim().isEmpty()) list.add(s.trim());
+        return list;
+    }
+
+    private java.util.List<String> splitNames(String names) {
+        if (names == null || names.trim().isEmpty()) return java.util.Collections.emptyList();
+        String[] arr = names.split("[,\u3001\\s]+");
+        java.util.List<String> list = new java.util.ArrayList<>();
+        for (String s : arr) if (!s.trim().isEmpty()) list.add(s.trim());
+        return list;
+    }
+
+    private java.util.List<Double> parseQtys(String str) {
+        java.util.List<Double> vals = new java.util.ArrayList<>();
+        if (str == null) return vals;
+        for (String seg : str.trim().split("[\\s,]+")) {
+            if (seg.isEmpty()) continue;
+            int idx = seg.indexOf(":");
+            if (idx < 0) idx = seg.indexOf('：');
+            String num = idx >= 0 ? seg.substring(idx + 1) : seg;
+            if (num.isEmpty()) { vals.add(null); continue; }
+            try { vals.add(Double.parseDouble(num)); } catch (NumberFormatException e) { vals.add(null); }
+        }
+        return vals;
     }
 
     @GetMapping("/file/{fileId}/print")

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -69,12 +69,55 @@ public class WorkRecordController {
     @GetMapping("/file/{fileId}/export")
     public void exportFilled(@PathVariable Long fileId, HttpServletResponse response) throws IOException {
         List<WorkRecord> list = repository.findByFileIdAndFilledTrue(fileId);
+        exportList(list, response);
+    }
+
+    @GetMapping("/date/{date}/export")
+    public void exportByDate(@PathVariable @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE) java.time.LocalDate date,
+                             HttpServletResponse response) throws IOException {
+        java.time.LocalDateTime start = date.atStartOfDay();
+        java.time.LocalDateTime end = start.plusDays(1);
+        List<WorkRecord> list = repository.findByUploadDate(start, end);
+        exportList(list, response);
+    }
+
+    private java.util.List<String> splitWorkers(String codes) {
+        if (codes == null || codes.trim().isEmpty()) return java.util.Collections.emptyList();
+        String[] arr = codes.split("[,\u3001\\s]+");
+        java.util.List<String> list = new java.util.ArrayList<>();
+        for (String s : arr) if (!s.trim().isEmpty()) list.add(s.trim());
+        return list;
+    }
+
+    private java.util.List<String> splitNames(String names) {
+        if (names == null || names.trim().isEmpty()) return java.util.Collections.emptyList();
+        String[] arr = names.split("[,\u3001\\s]+");
+        java.util.List<String> list = new java.util.ArrayList<>();
+        for (String s : arr) if (!s.trim().isEmpty()) list.add(s.trim());
+        return list;
+    }
+
+    private java.util.List<Double> parseQtys(String str) {
+        java.util.List<Double> vals = new java.util.ArrayList<>();
+        if (str == null) return vals;
+        for (String seg : str.trim().split("[\\s,]+")) {
+            if (seg.isEmpty()) continue;
+            int idx = seg.indexOf(":");
+            if (idx < 0) idx = seg.indexOf('：');
+            String num = idx >= 0 ? seg.substring(idx + 1) : seg;
+            if (num.isEmpty()) { vals.add(null); continue; }
+            try { vals.add(Double.parseDouble(num)); } catch (NumberFormatException e) { vals.add(null); }
+        }
+        return vals;
+    }
+
+    private void exportList(java.util.List<WorkRecord> list, HttpServletResponse response) throws IOException {
         Workbook wb = new org.apache.poi.xssf.usermodel.XSSFWorkbook();
         Sheet sheet = wb.createSheet("records");
         CellStyle twoDec = wb.createCellStyle();
         twoDec.setDataFormat(wb.createDataFormat().getFormat("0.00"));
         Row head = sheet.createRow(0);
-        String[] titles = {"通知单号","产品名称","图号","批次号","工序代码","工时","产量","人员代码","姓名","数量分配","工时分配","合格数","工时小计"};
+        String[] titles = {"通知单号","产品名称","图号","批次号","工序代码","工时","产量","人员代码","姓名","数量分配","工时分配","起始日期","结束日期","合格数","工时小计"};
         for (int i = 0; i < titles.length; i++) {
             head.createCell(i).setCellValue(titles[i]);
         }
@@ -121,6 +164,8 @@ public class WorkRecordController {
                 else row.createCell(c++).setCellValue("");
 
                 if (i == 0) {
+                    row.createCell(c++).setCellValue(r.getStartTime() == null ? "" : r.getStartTime().toLocalDate().toString());
+                    row.createCell(c++).setCellValue(r.getEndTime() == null ? "" : r.getEndTime().toLocalDate().toString());
                     if (r.getQualifiedQty() != null) {
                         Cell cell = row.createCell(c++);
                         cell.setCellValue(r.getQualifiedQty());
@@ -136,6 +181,8 @@ public class WorkRecordController {
                 } else {
                     row.createCell(c++).setCellValue("");
                     row.createCell(c++).setCellValue("");
+                    row.createCell(c++).setCellValue("");
+                    row.createCell(c++).setCellValue("");
                 }
             }
         }
@@ -143,36 +190,6 @@ public class WorkRecordController {
         response.setHeader("Content-Disposition", "attachment; filename=records.xlsx");
         wb.write(response.getOutputStream());
         wb.close();
-    }
-
-    private java.util.List<String> splitWorkers(String codes) {
-        if (codes == null || codes.trim().isEmpty()) return java.util.Collections.emptyList();
-        String[] arr = codes.split("[,\u3001\\s]+");
-        java.util.List<String> list = new java.util.ArrayList<>();
-        for (String s : arr) if (!s.trim().isEmpty()) list.add(s.trim());
-        return list;
-    }
-
-    private java.util.List<String> splitNames(String names) {
-        if (names == null || names.trim().isEmpty()) return java.util.Collections.emptyList();
-        String[] arr = names.split("[,\u3001\\s]+");
-        java.util.List<String> list = new java.util.ArrayList<>();
-        for (String s : arr) if (!s.trim().isEmpty()) list.add(s.trim());
-        return list;
-    }
-
-    private java.util.List<Double> parseQtys(String str) {
-        java.util.List<Double> vals = new java.util.ArrayList<>();
-        if (str == null) return vals;
-        for (String seg : str.trim().split("[\\s,]+")) {
-            if (seg.isEmpty()) continue;
-            int idx = seg.indexOf(":");
-            if (idx < 0) idx = seg.indexOf('：');
-            String num = idx >= 0 ? seg.substring(idx + 1) : seg;
-            if (num.isEmpty()) { vals.add(null); continue; }
-            try { vals.add(Double.parseDouble(num)); } catch (NumberFormatException e) { vals.add(null); }
-        }
-        return vals;
     }
 
     @GetMapping("/file/{fileId}/print")

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -72,8 +72,10 @@ public class WorkRecordController {
         Workbook wb = new org.apache.poi.xssf.usermodel.XSSFWorkbook();
         Sheet sheet = wb.createSheet("records");
         Row head = sheet.createRow(0);
-        String[] titles = {"通知单号","产品名称","图号","批次号","工序代码","工时","产量","人员代码","姓名","合格数","工时小计"};
-        for (int i = 0; i < titles.length; i++) head.createCell(i).setCellValue(titles[i]);
+        String[] titles = {"通知单号","产品名称","图号","批次号","工序代码","工时","产量","人员代码","姓名","数量分配","工时分配","合格数","工时小计"};
+        for (int i = 0; i < titles.length; i++) {
+            head.createCell(i).setCellValue(titles[i]);
+        }
 
         int rowIdx = 1;
         for (WorkRecord r : list) {
@@ -94,15 +96,25 @@ public class WorkRecordController {
                 if (r.getPlanQty() != null) row.createCell(c++).setCellValue(r.getPlanQty()); else row.createCell(c++).setCellValue("");
                 row.createCell(c++).setCellValue(i < codes.size() ? n(codes.get(i)) : "");
                 row.createCell(c++).setCellValue(i < names.size() ? n(names.get(i)) : "");
+
                 Double q = i < qtys.size() ? qtys.get(i) : null;
                 if (q != null) row.createCell(c++).setCellValue(q);
-                else if (i == 0 && r.getQualifiedQty() != null && max == 1) row.createCell(c++).setCellValue(r.getQualifiedQty());
                 else row.createCell(c++).setCellValue("");
-                Double hs = null;
-                if (q != null && r.getHours() != null) hs = q * r.getHours();
-                if (hs != null) row.createCell(c++).setCellValue(hs);
-                else if (i == 0 && r.getHourSubtotal() != null && max == 1) row.createCell(c++).setCellValue(r.getHourSubtotal());
+
+                Double workerHours = null;
+                if (q != null && r.getHours() != null) workerHours = q * r.getHours();
+                if (workerHours != null) row.createCell(c++).setCellValue(workerHours);
                 else row.createCell(c++).setCellValue("");
+
+                if (i == 0) {
+                    if (r.getQualifiedQty() != null) row.createCell(c++).setCellValue(r.getQualifiedQty());
+                    else row.createCell(c++).setCellValue("");
+                    if (r.getHourSubtotal() != null) row.createCell(c++).setCellValue(r.getHourSubtotal());
+                    else row.createCell(c++).setCellValue("");
+                } else {
+                    row.createCell(c++).setCellValue("");
+                    row.createCell(c++).setCellValue("");
+                }
             }
         }
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -71,6 +71,8 @@ public class WorkRecordController {
         List<WorkRecord> list = repository.findByFileIdAndFilledTrue(fileId);
         Workbook wb = new org.apache.poi.xssf.usermodel.XSSFWorkbook();
         Sheet sheet = wb.createSheet("records");
+        CellStyle twoDec = wb.createCellStyle();
+        twoDec.setDataFormat(wb.createDataFormat().getFormat("0.00"));
         Row head = sheet.createRow(0);
         String[] titles = {"通知单号","产品名称","图号","批次号","工序代码","工时","产量","人员代码","姓名","数量分配","工时分配","合格数","工时小计"};
         for (int i = 0; i < titles.length; i++) {
@@ -92,24 +94,44 @@ public class WorkRecordController {
                 row.createCell(c++).setCellValue(n(r.getDrawingNumber()));
                 row.createCell(c++).setCellValue(n(r.getBatchNumber()));
                 row.createCell(c++).setCellValue(n(r.getProcessCode()));
-                if (r.getHours() != null) row.createCell(c++).setCellValue(r.getHours()); else row.createCell(c++).setCellValue("");
+                if (r.getHours() != null) {
+                    Cell cell = row.createCell(c++);
+                    cell.setCellValue(r.getHours());
+                    cell.setCellStyle(twoDec);
+                } else row.createCell(c++).setCellValue("");
                 if (r.getPlanQty() != null) row.createCell(c++).setCellValue(r.getPlanQty()); else row.createCell(c++).setCellValue("");
                 row.createCell(c++).setCellValue(i < codes.size() ? n(codes.get(i)) : "");
                 row.createCell(c++).setCellValue(i < names.size() ? n(names.get(i)) : "");
 
                 Double q = i < qtys.size() ? qtys.get(i) : null;
-                if (q != null) row.createCell(c++).setCellValue(q);
+                if (q != null) {
+                    Cell cell = row.createCell(c++);
+                    cell.setCellValue(q);
+                    cell.setCellStyle(twoDec);
+                }
                 else row.createCell(c++).setCellValue("");
 
                 Double workerHours = null;
                 if (q != null && r.getHours() != null) workerHours = q * r.getHours();
-                if (workerHours != null) row.createCell(c++).setCellValue(workerHours);
+                if (workerHours != null) {
+                    Cell cell = row.createCell(c++);
+                    cell.setCellValue(workerHours);
+                    cell.setCellStyle(twoDec);
+                }
                 else row.createCell(c++).setCellValue("");
 
                 if (i == 0) {
-                    if (r.getQualifiedQty() != null) row.createCell(c++).setCellValue(r.getQualifiedQty());
+                    if (r.getQualifiedQty() != null) {
+                        Cell cell = row.createCell(c++);
+                        cell.setCellValue(r.getQualifiedQty());
+                        cell.setCellStyle(twoDec);
+                    }
                     else row.createCell(c++).setCellValue("");
-                    if (r.getHourSubtotal() != null) row.createCell(c++).setCellValue(r.getHourSubtotal());
+                    if (r.getHourSubtotal() != null) {
+                        Cell cell = row.createCell(c++);
+                        cell.setCellValue(r.getHourSubtotal());
+                        cell.setCellStyle(twoDec);
+                    }
                     else row.createCell(c++).setCellValue("");
                 } else {
                     row.createCell(c++).setCellValue("");

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -177,8 +177,10 @@ public class WorkRecordController {
     }
 
     @DeleteMapping("/{id}")
+    @Transactional
     public void delete(@PathVariable Long id) {
         repository.deleteById(id);
+        repository.flush();
     }
 
     @PostMapping

--- a/backend/src/main/java/com/example/worktime/model/WorkRecord.java
+++ b/backend/src/main/java/com/example/worktime/model/WorkRecord.java
@@ -78,6 +78,7 @@ public class WorkRecord {
     private String workerQtys;
 
     // 合格数量
+    @javax.persistence.Column(precision = 10, scale = 2)
     private Double qualifiedQty;
 
     // 工时小计 = 合格数量 * 单件工时

--- a/backend/src/main/java/com/example/worktime/model/WorkRecord.java
+++ b/backend/src/main/java/com/example/worktime/model/WorkRecord.java
@@ -78,7 +78,7 @@ public class WorkRecord {
     private String workerQtys;
 
     // 合格数量
-    private Integer qualifiedQty;
+    private Double qualifiedQty;
 
     // 工时小计 = 合格数量 * 单件工时
     private Double hourSubtotal;
@@ -156,8 +156,8 @@ public class WorkRecord {
     public String getWorkerQtys() { return workerQtys; }
     public void setWorkerQtys(String workerQtys) { this.workerQtys = workerQtys; }
 
-    public Integer getQualifiedQty() { return qualifiedQty; }
-    public void setQualifiedQty(Integer qualifiedQty) { this.qualifiedQty = qualifiedQty; }
+    public Double getQualifiedQty() { return qualifiedQty; }
+    public void setQualifiedQty(Double qualifiedQty) { this.qualifiedQty = qualifiedQty; }
 
     public Double getHourSubtotal() { return hourSubtotal; }
     public void setHourSubtotal(Double hourSubtotal) { this.hourSubtotal = hourSubtotal; }

--- a/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
@@ -10,5 +10,9 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
 
     java.util.List<WorkRecord> findByFileIdAndFilledTrue(Long fileId);
 
+    @org.springframework.data.jpa.repository.Query("select r from WorkRecord r where r.file.uploadTime >= :start and r.file.uploadTime < :end and r.filled = true")
+    java.util.List<WorkRecord> findByUploadDate(@org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
+                                                @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
+
     void deleteByFileId(Long fileId);
 }

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS work_record (
     worker_codes VARCHAR(255),
     worker_names VARCHAR(255),
     worker_qtys VARCHAR(255),
-    qualified_qty INT,
+    qualified_qty DOUBLE,
     hour_subtotal DOUBLE,
     filled BOOLEAN,
     start_time DATETIME,

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS work_record (
     worker_codes VARCHAR(255),
     worker_names VARCHAR(255),
     worker_qtys VARCHAR(255),
-    qualified_qty DOUBLE,
+    qualified_qty DECIMAL(10,2),
     hour_subtotal DOUBLE,
     filled BOOLEAN,
     start_time DATETIME,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
 </head>
 <body class="bg-light">
   <div id="app"></div>
-  <script type="module" src="/src/main.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -47,6 +47,12 @@ body {
   resize: none;
 }
 
+/* highlight editable fields so they stand out against table background */
+.edit-highlight {
+  background-color: #fffbe6;
+  border-color: #f0ad4e;
+}
+
 /* Only show the preview table when printing */
 @media print {
   body * {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -36,6 +36,12 @@ body {
   max-width: 260px;
 }
 
+/* textarea that expands vertically to fit its content */
+.auto-grow {
+  overflow: hidden;
+  resize: none;
+}
+
 /* Only show the preview table when printing */
 @media print {
   body * {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -29,6 +29,13 @@ body {
   width: 300px;
 }
 
+/* allow table cells to wrap long text without widening the table */
+.wrap-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 260px;
+}
+
 /* Only show the preview table when printing */
 @media print {
   body * {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -33,7 +33,12 @@ body {
 .wrap-text {
   white-space: pre-wrap;
   word-break: break-word;
-  max-width: 260px;
+  max-width: 320px;
+}
+
+/* wider inputs for worker allocations */
+.alloc-input {
+  width: 90px;
 }
 
 /* textarea that expands vertically to fit its content */

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -208,7 +208,16 @@ export default {
       if (idx !== -1) this.records.splice(idx, 1)
     },
     async processRecords(list) {
-      this.records = list.map(r => ({ ...r, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', workerHourInputs:'', codeToName:{} }))
+      this.records = list.map(r => ({
+        ...r,
+        editing: false,
+        workshop: '',
+        team: '',
+        workerQtys: r.workerQtys || '',
+        workerHours: '',
+        workerHourInputs: '',
+        codeToName: {}
+      }))
       for (const rec of this.records) {
         if (rec.qualifiedQty != null && rec.hours != null) {
           rec.hourSubtotal = rec.qualifiedQty * rec.hours
@@ -287,7 +296,7 @@ export default {
       if (qtys.length !== codes.length) {
         const share = rec.qualifiedQty / codes.length
         qtys = codes.map(() => share)
-        rec.workerQtys = qtys.join(' ')
+        rec.workerQtys = qtys.map(q => q.toFixed(2)).join(' ')
       }
       const hoursArr = codes.map((_,i) => (qtys[i] || 0) * rec.hours)
       rec.workerHours = codes.map((c,i) => {

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -231,8 +231,14 @@ export default {
     },
     async deleteRecord(rec) {
       if (!confirm('确定删除这条记录?')) return
-      const idx = this.records.indexOf(rec)
-      if (idx !== -1) this.records.splice(idx, 1)
+      try {
+        await axios.delete(`http://localhost:8080/api/workrecords/${rec.id}`)
+        const idx = this.records.indexOf(rec)
+        if (idx !== -1) this.records.splice(idx, 1)
+      } catch (e) {
+        console.error(e)
+        alert('删除失败')
+      }
     },
     async processRecords(list) {
       this.records = list.map(r => ({

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -8,10 +8,12 @@
     <div class="input-group mb-2" style="max-width:400px;">
       <select class="form-select form-select-sm" v-model="selectedFileId">
         <option value="" disabled>选择文件查看全部</option>
-        <option v-for="f in files" :key="f.id" :value="f.id">{{ f.fileName }}</option>
+        <option v-for="f in files" :key="f.id" :value="f.id">{{ f.fileName }} ({{ f.uploadTime ? f.uploadTime.slice(0,10) : '' }})</option>
       </select>
       <button class="btn btn-outline-secondary btn-sm" @click="loadFile" :disabled="!selectedFileId">加载</button>
       <button class="btn btn-outline-primary btn-sm" @click="exportFile" :disabled="!records.length">导出</button>
+      <input type="date" class="form-control form-control-sm ms-1" style="max-width:160px" v-model="exportDate">
+      <button class="btn btn-outline-primary btn-sm ms-1" @click="exportByDate" :disabled="!exportDate">按日期导出</button>
     </div>
     <div class="mb-2" v-if="records.length">
       产量: {{ planQty }} | 总合格数: {{ totalQualified }} | 已填写 {{ records.length }} 条
@@ -33,6 +35,8 @@
           <th>姓名</th>
           <th>车间</th>
           <th>班组</th>
+          <th>起始日期</th>
+          <th>结束日期</th>
           <th>合格数</th>
           <th>工时小计</th>
           <th>工时分配</th>
@@ -87,6 +91,14 @@
           <td class="wrap-text">{{ rec.workshop }}</td>
           <td class="wrap-text">{{ rec.team }}</td>
           <td>
+            <span v-if="!rec.editing">{{ rec.startDate }}</span>
+            <input v-else type="date" class="form-control form-control-sm edit-highlight" v-model="rec.startDate" style="width:130px" />
+          </td>
+          <td>
+            <span v-if="!rec.editing">{{ rec.endDate }}</span>
+            <input v-else type="date" class="form-control form-control-sm edit-highlight" v-model="rec.endDate" style="width:130px" />
+          </td>
+          <td>
             <span v-if="!rec.editing">{{ rec.qualifiedQty }}</span>
             <input v-else type="number" step="0.01" class="form-control form-control-sm edit-highlight" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" @blur="validatePlanQty();validateQtyAllocation(rec);validateHourAllocation(rec)" style="width:80px" />
           </td>
@@ -132,6 +144,7 @@ export default {
       searchBarcode: '',
       files: [],
       selectedFileId: '',
+      exportDate: '',
       viewOnly: false
     }
   },
@@ -182,6 +195,19 @@ export default {
       a.click()
       window.URL.revokeObjectURL(url)
     },
+    async exportByDate() {
+      if (!this.exportDate) return
+      const res = await axios.get(
+        `http://localhost:8080/api/workrecords/date/${this.exportDate}/export`,
+        { responseType: 'blob' }
+      )
+      const url = window.URL.createObjectURL(new Blob([res.data]))
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `records_${this.exportDate}.xlsx`
+      a.click()
+      window.URL.revokeObjectURL(url)
+    },
     async searchByBarcode() {
       const code = this.searchBarcode.trim()
       if (!code) { this.records = []; return }
@@ -202,7 +228,12 @@ export default {
       }
       this.validateQtyAllocation(rec)
       this.validateHourAllocation(rec)
-      await axios.put(`http://localhost:8080/api/workrecords/${rec.id}`, rec)
+      const payload = {
+        ...rec,
+        startTime: rec.startDate ? rec.startDate + 'T00:00:00' : null,
+        endTime: rec.endDate ? rec.endDate + 'T00:00:00' : null
+      }
+      await axios.put(`http://localhost:8080/api/workrecords/${rec.id}`, payload)
       rec.editing = false
       this.searchByBarcode()
     },
@@ -224,7 +255,9 @@ export default {
           workerQtyVals: [],
           workerHourVals: [],
           workerNamesList: [],
-          codeToName: {}
+          codeToName: {},
+          startDate: '',
+          endDate: ''
         }
       if (rec.qualifiedQty != null && rec.hours != null) {
         rec.hourSubtotal = rec.qualifiedQty * rec.hours
@@ -259,7 +292,9 @@ export default {
         workerQtyVals: this.parseAllocValues(r.workerQtys),
         workerHourVals: [],
         workerNamesList: [],
-        codeToName: {}
+        codeToName: {},
+        startDate: r.startTime ? r.startTime.slice(0,10) : '',
+        endDate: r.endTime ? r.endTime.slice(0,10) : ''
       }))
       for (const rec of this.records) {
         if (rec.qualifiedQty != null && rec.hours != null) {

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -70,7 +70,7 @@
               v-else
               class="form-control form-control-sm"
               v-model="rec.workerQtys"
-              @input="() => { rec.workerHourInputs=''; computeWorkerHours(rec) }"
+              @input="computeWorkerHours(rec)"
               style="width:80px"
             />
           </td>
@@ -236,7 +236,7 @@ export default {
     },
     onQtyChange(rec) {
       this.computeSubtotal(rec)
-      if (rec.workerHourInputs && rec.workerHourInputs.trim()) {
+      if (this.parseAllocValues(rec.workerHourInputs).some(v => v != null)) {
         this.computeQtysFromHours(rec)
       } else {
         this.computeWorkerHours(rec)
@@ -244,7 +244,7 @@ export default {
     },
     onWorkerCodesChange(rec) {
       this.lookupWorker(rec)
-      if (rec.workerHourInputs && rec.workerHourInputs.trim()) {
+      if (this.parseAllocValues(rec.workerHourInputs).some(v => v != null)) {
         this.computeQtysFromHours(rec)
       } else {
         this.computeWorkerHours(rec)
@@ -280,60 +280,80 @@ export default {
       rec.workerNames = names.join(',')
       rec.workshop = Array.from(workshops).join(',')
       rec.team = Array.from(teams).join(',')
+      const qtyVals = this.parseAllocValues(rec.workerQtys)
+      const hourVals = this.parseAllocValues(rec.workerHourInputs)
+      rec.workerQtys = this.formatAllocString(names, qtyVals.length === names.length ? qtyVals : undefined)
+      rec.workerHourInputs = this.formatAllocString(names, hourVals.length === names.length ? hourVals : undefined)
     },
     computeWorkerHours(rec) {
       const codes = rec.workerCodes
         ? rec.workerCodes.trim().split(/[,\u3001\s]+/)
         : []
+      const names = codes.map(c => (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c)
       if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
         rec.workerHours = ''
-        if (!rec.workerQtys) rec.workerQtys = ''
-        rec.workerHourInputs = ''
+        rec.workerHourInputs = this.formatAllocString(names)
+        rec.workerQtys = this.formatAllocString(names)
         return
       }
-      let qtys = []
-      if (rec.workerQtys && rec.workerQtys.trim()) {
-        qtys = rec.workerQtys.trim().split(/\s+/).map(n => parseFloat(n))
+      let qtyVals = this.parseAllocValues(rec.workerQtys)
+      const hasAny = qtyVals.some(v => v != null)
+      if (!hasAny) {
+        rec.workerHourInputs = this.formatAllocString(names)
+        rec.workerHours = ''
+        return
       }
-      if (qtys.length !== codes.length) {
-        const share = rec.qualifiedQty / codes.length
-        qtys = codes.map(() => share)
-        rec.workerQtys = qtys.map(q => q.toFixed(2)).join(' ')
-      }
-      const hoursArr = codes.map((_,i) => (qtys[i] || 0) * rec.hours)
-      rec.workerHours = codes.map((c,i) => {
-        const name = (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c
-        return `${name}:${hoursArr[i].toFixed(2)}`
-      }).join(',')
-      rec.workerHourInputs = hoursArr.map(h => h.toFixed(2)).join(' ')
+      while (qtyVals.length < codes.length) qtyVals.push(0)
+      qtyVals = qtyVals.map(v => (v == null || isNaN(v)) ? 0 : v)
+      const hoursArr = qtyVals.map(q => (q || 0) * rec.hours)
+      rec.workerHours = names.map((n,i) => `${n}:${hoursArr[i].toFixed(2)}`).join(',')
+      rec.workerHourInputs = this.formatAllocString(names, hoursArr)
+      rec.workerQtys = this.formatAllocString(names, qtyVals)
     },
     computeQtysFromHours(rec) {
       const codes = rec.workerCodes
         ? rec.workerCodes.trim().split(/[,\u3001\s]+/)
         : []
+      const names = codes.map(c => (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c)
       if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
         rec.workerHours = ''
-        rec.workerQtys = ''
+        rec.workerQtys = this.formatAllocString(names)
         return
       }
-      let hours = []
-      if (rec.workerHourInputs && rec.workerHourInputs.trim()) {
-        hours = rec.workerHourInputs.trim().split(/\s+/).map(n => parseFloat(n))
+      let hours = this.parseAllocValues(rec.workerHourInputs)
+      const hasAny = hours.some(v => v != null)
+      if (!hasAny) {
+        rec.workerQtys = this.formatAllocString(names)
+        rec.workerHours = ''
+        return
       }
-      if (hours.length !== codes.length) {
-        hours = codes.map(() => 0)
-      }
+      while (hours.length < codes.length) hours.push(0)
+      hours = hours.map(v => (v == null || isNaN(v)) ? 0 : v)
       const total = rec.qualifiedQty * rec.hours
       const sum = hours.reduce((a,b) => a + (b || 0), 0)
       if (total != null && sum > total) {
         alert('填写的工时超过总工时')
       }
       const qtys = hours.map(h => rec.hours ? h / rec.hours : 0)
-      rec.workerQtys = qtys.map(q => q.toFixed(2)).join(' ')
-      rec.workerHours = codes.map((c,i) => {
-        const name = (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c
-        return `${name}:${(hours[i] || 0).toFixed(2)}`
-      }).join(',')
+      rec.workerQtys = this.formatAllocString(names, qtys)
+      rec.workerHours = names.map((n,i) => `${n}:${(hours[i] || 0).toFixed(2)}`).join(',')
+    },
+    parseAllocValues(str) {
+      if (!str) return []
+      return str.trim().split(/[\s,]+/).map(seg => {
+        if (!seg) return null
+        const idx = seg.indexOf(':')
+        const numStr = idx >= 0 ? seg.slice(idx + 1) : seg
+        if (numStr === '') return null
+        const v = parseFloat(numStr)
+        return isNaN(v) ? null : v
+      })
+    },
+    formatAllocString(names, values) {
+      return names.map((n, i) => {
+        const val = values && values[i] != null && !isNaN(values[i]) ? values[i].toFixed(2) : ''
+        return `${n}:${val}`
+      }).join(' ')
     },
     autoGrow(event) {
       const el = event.target

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -74,8 +74,7 @@
               >
                 <input
                   type="number"
-                  class="form-control form-control-sm"
-                  style="width:70px"
+                  class="form-control form-control-sm alloc-input"
                   v-model.number="rec.workerQtyVals[idx]"
                   :placeholder="name"
                   @input="onQtyFieldsInput(rec)"
@@ -101,8 +100,7 @@
               >
                 <input
                   type="number"
-                  class="form-control form-control-sm"
-                  style="width:70px"
+                  class="form-control form-control-sm alloc-input"
                   v-model.number="rec.workerHourVals[idx]"
                   :placeholder="name"
                   @input="onHourFieldsInput(rec)"

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -78,6 +78,7 @@
                   v-model.number="rec.workerQtyVals[idx]"
                   :placeholder="name"
                   @input="onQtyFieldsInput(rec)"
+                  @blur="validateQtyAllocation(rec)"
                 />
               </div>
             </div>
@@ -87,7 +88,7 @@
           <td class="wrap-text">{{ rec.team }}</td>
           <td>
             <span v-if="!rec.editing">{{ rec.qualifiedQty }}</span>
-            <input v-else type="number" step="0.01" class="form-control form-control-sm edit-highlight" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" style="width:80px" />
+            <input v-else type="number" step="0.01" class="form-control form-control-sm edit-highlight" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" @blur="validatePlanQty();validateQtyAllocation(rec);validateHourAllocation(rec)" style="width:80px" />
           </td>
           <td>{{ rec.hourSubtotal }}</td>
           <td class="wrap-text">
@@ -104,6 +105,7 @@
                   v-model.number="rec.workerHourVals[idx]"
                   :placeholder="name"
                   @input="onHourFieldsInput(rec)"
+                  @blur="validateHourAllocation(rec)"
                 />
               </div>
             </div>
@@ -198,6 +200,8 @@ export default {
       if (this.planQty != null && total > this.planQty) {
         alert('总合格数已超过产量，请确认')
       }
+      this.validateQtyAllocation(rec)
+      this.validateHourAllocation(rec)
       await axios.put(`http://localhost:8080/api/workrecords/${rec.id}`, rec)
       rec.editing = false
       this.searchByBarcode()
@@ -268,10 +272,6 @@ export default {
     computeSubtotal(row) {
       if (row.qualifiedQty != null && row.hours != null) row.hourSubtotal = row.qualifiedQty * row.hours
       else row.hourSubtotal = null
-      const total = this.records.reduce((sum, r) => sum + (r.qualifiedQty || 0), 0)
-      if (this.planQty != null && total > this.planQty) {
-        alert('总合格数已超过产量，请确认')
-      }
     },
     onQtyChange(rec) {
       this.computeSubtotal(rec)
@@ -294,6 +294,27 @@ export default {
     },
     onHourFieldsInput(rec) {
       this.computeQtysFromHours(rec)
+    },
+    validatePlanQty() {
+      const total = this.records.reduce((sum, r) => sum + (r.qualifiedQty || 0), 0)
+      if (this.planQty != null && total > this.planQty) {
+        alert('总合格数已超过产量，请确认')
+      }
+    },
+    validateQtyAllocation(rec) {
+      if (!rec || !Array.isArray(rec.workerQtyVals)) return
+      const sum = rec.workerQtyVals.reduce((a, b) => a + (parseFloat(b) || 0), 0)
+      if (rec.qualifiedQty != null && sum > rec.qualifiedQty) {
+        alert('分配数量超过合格数量')
+      }
+    },
+    validateHourAllocation(rec) {
+      if (!rec || !Array.isArray(rec.workerHourVals)) return
+      const sum = rec.workerHourVals.reduce((a,b) => a + (parseFloat(b) || 0), 0)
+      const total = (rec.qualifiedQty || 0) * (rec.hours || 0)
+      if (total && sum > total) {
+        alert('填写的工时超过总工时')
+      }
     },
     async lookupWorker(rec) {
       const codes = rec.workerCodes ? rec.workerCodes.split(/[,\u3001\s]+/) : []
@@ -359,6 +380,8 @@ export default {
       rec.workerHourVals = hourList
       rec.workerHours = names.map((n,i) => `${n}:${hourList[i].toFixed(2)}`).join(',')
       rec.workerQtys = this.formatAllocString(names, qtyList)
+      const sum = qtyList.reduce((a,b) => a + (b || 0), 0)
+      rec._qtyOverflow = rec.qualifiedQty != null && sum > rec.qualifiedQty
     },
     computeQtysFromHours(rec) {
       const names = rec.workerNamesList || []
@@ -378,12 +401,12 @@ export default {
       while (hourList.length < names.length) hourList.push(0)
       const total = rec.qualifiedQty * rec.hours
       const sum = hourList.reduce((a,b) => a + (b || 0), 0)
-      if (total != null && sum > total) {
-        alert('填写的工时超过总工时')
-      }
+      rec._hourOverflow = total != null && sum > total
       const qtyList = hourList.map(h => rec.hours ? h / rec.hours : 0)
       rec.workerQtyVals = qtyList
       rec.workerQtys = this.formatAllocString(names, qtyList)
+      const qtySum = qtyList.reduce((a,b) => a + (b || 0), 0)
+      rec._qtyOverflow = rec.qualifiedQty != null && qtySum > rec.qualifiedQty
       rec.workerHours = names.map((n,i) => `${n}:${hourList[i].toFixed(2)}`).join(',')
     },
     parseAllocValues(str) {

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -42,9 +42,9 @@
       <tbody>
         <tr v-for="rec in records" :key="rec.id">
           <td>{{ rec.id }}</td>
-          <td>{{ rec.notificationNumber }}</td>
-          <td>{{ rec.productName }}</td>
-          <td>{{ rec.drawingNumber }}</td>
+          <td class="wrap-text">{{ rec.notificationNumber }}</td>
+          <td class="wrap-text">{{ rec.productName }}</td>
+          <td class="wrap-text">{{ rec.drawingNumber }}</td>
           <td>
             <span v-if="!rec.editing">{{ rec.batchNumber }}</span>
             <input v-else class="form-control form-control-sm" v-model="rec.batchNumber" style="width:80px" />
@@ -69,14 +69,14 @@
             <input v-else class="form-control form-control-sm" v-model="rec.workerQtys" @input="computeWorkerHours(rec)" style="width:80px" />
           </td>
           <td class="wrap-text">{{ rec.workerNames }}</td>
-          <td>{{ rec.workshop }}</td>
-          <td>{{ rec.team }}</td>
+          <td class="wrap-text">{{ rec.workshop }}</td>
+          <td class="wrap-text">{{ rec.team }}</td>
           <td>
             <span v-if="!rec.editing">{{ rec.qualifiedQty }}</span>
             <input v-else type="number" class="form-control form-control-sm" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" style="width:80px" />
           </td>
           <td>{{ rec.hourSubtotal }}</td>
-          <td>{{ rec.workerHours }}</td>
+          <td class="wrap-text">{{ rec.workerHours }}</td>
           <td v-if="!viewOnly">
             <template v-if="!rec.editing">
               <button class="btn btn-sm btn-outline-primary me-1" @click="rec.editing=true">编辑</button>
@@ -179,7 +179,7 @@ export default {
       if (!this.records.length) return
       const id = this.records[0].id
       const res = await axios.post(`http://localhost:8080/api/workrecords/duplicate/${id}`)
-      const rec = { ...res.data, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'' }
+      const rec = { ...res.data, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', codeToName:{} }
       if (rec.qualifiedQty != null && rec.hours != null) {
         rec.hourSubtotal = rec.qualifiedQty * rec.hours
       }
@@ -193,7 +193,7 @@ export default {
       if (idx !== -1) this.records.splice(idx, 1)
     },
     async processRecords(list) {
-      this.records = list.map(r => ({ ...r, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'' }))
+      this.records = list.map(r => ({ ...r, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', codeToName:{} }))
       for (const rec of this.records) {
         if (rec.qualifiedQty != null && rec.hours != null) {
           rec.hourSubtotal = rec.qualifiedQty * rec.hours
@@ -223,13 +223,17 @@ export default {
       const names = []
       const workshops = new Set()
       const teams = new Set()
+      const map = {}
       for (const c of codes) {
         if (!c) continue
         try {
           const res = await axios.get(`http://localhost:8080/api/workers/code/${encodeURIComponent(c)}`)
           const w = res.data
           if (w) {
-            if (w.name) names.push(w.name)
+            if (w.name) {
+              names.push(w.name)
+              map[c] = w.name
+            }
             if (w.workshop) workshops.add(w.workshop)
             if (w.team) teams.add(w.team)
           } else {
@@ -240,6 +244,7 @@ export default {
           alert(`未找到人员 ${c}`)
         }
       }
+      rec.codeToName = map
       rec.workerNames = names.join(',')
       rec.workshop = Array.from(workshops).join(',')
       rec.team = Array.from(teams).join(',')
@@ -260,7 +265,10 @@ export default {
         qtys = codes.map(() => share)
         rec.workerQtys = qtys.join(' ')
       }
-      rec.workerHours = codes.map((c,i)=> `${c}:${(qtys[i]||0)*rec.hours}` ).join(',')
+      rec.workerHours = codes.map((c,i) => {
+        const name = (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c
+        return `${name}:${(qtys[i] || 0) * rec.hours}`
+      }).join(',')
     },
     autoGrow(event) {
       const el = event.target

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -47,7 +47,7 @@
           <td class="wrap-text">{{ rec.drawingNumber }}</td>
           <td>
             <span v-if="!rec.editing">{{ rec.batchNumber }}</span>
-            <input v-else class="form-control form-control-sm" v-model="rec.batchNumber" style="width:80px" />
+            <input v-else class="form-control form-control-sm edit-highlight" v-model="rec.batchNumber" style="width:80px" />
           </td>
           <td>{{ rec.processCode }}</td>
           <td>{{ rec.hours }}</td>
@@ -56,7 +56,7 @@
             <span v-if="!rec.editing">{{ rec.workerCodes }}</span>
             <textarea
               v-else
-              class="form-control form-control-sm auto-grow"
+              class="form-control form-control-sm auto-grow edit-highlight"
               style="width:100%;"
               v-model="rec.workerCodes"
               @focus="autoGrow"
@@ -74,7 +74,7 @@
               >
                 <input
                   type="number"
-                  class="form-control form-control-sm alloc-input"
+                  class="form-control form-control-sm alloc-input edit-highlight"
                   v-model.number="rec.workerQtyVals[idx]"
                   :placeholder="name"
                   @input="onQtyFieldsInput(rec)"
@@ -87,7 +87,7 @@
           <td class="wrap-text">{{ rec.team }}</td>
           <td>
             <span v-if="!rec.editing">{{ rec.qualifiedQty }}</span>
-            <input v-else type="number" step="0.01" class="form-control form-control-sm" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" style="width:80px" />
+            <input v-else type="number" step="0.01" class="form-control form-control-sm edit-highlight" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" style="width:80px" />
           </td>
           <td>{{ rec.hourSubtotal }}</td>
           <td class="wrap-text">
@@ -100,7 +100,7 @@
               >
                 <input
                   type="number"
-                  class="form-control form-control-sm alloc-input"
+                  class="form-control form-control-sm alloc-input edit-highlight"
                   v-model.number="rec.workerHourVals[idx]"
                   :placeholder="name"
                   @input="onHourFieldsInput(rec)"

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -66,7 +66,13 @@
           </td>
           <td>
             <span v-if="!rec.editing">{{ rec.workerQtys }}</span>
-            <input v-else class="form-control form-control-sm" v-model="rec.workerQtys" @input="computeWorkerHours(rec)" style="width:80px" />
+            <input
+              v-else
+              class="form-control form-control-sm"
+              v-model="rec.workerQtys"
+              @input="() => { rec.workerHourInputs=''; computeWorkerHours(rec) }"
+              style="width:80px"
+            />
           </td>
           <td class="wrap-text">{{ rec.workerNames }}</td>
           <td class="wrap-text">{{ rec.workshop }}</td>
@@ -76,7 +82,16 @@
             <input v-else type="number" class="form-control form-control-sm" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" style="width:80px" />
           </td>
           <td>{{ rec.hourSubtotal }}</td>
-          <td class="wrap-text">{{ rec.workerHours }}</td>
+          <td class="wrap-text">
+            <span v-if="!rec.editing">{{ rec.workerHours }}</span>
+            <input
+              v-else
+              class="form-control form-control-sm"
+              v-model="rec.workerHourInputs"
+              @input="computeQtysFromHours(rec)"
+              style="width:100px"
+            />
+          </td>
           <td v-if="!viewOnly">
             <template v-if="!rec.editing">
               <button class="btn btn-sm btn-outline-primary me-1" @click="rec.editing=true">编辑</button>
@@ -179,7 +194,7 @@ export default {
       if (!this.records.length) return
       const id = this.records[0].id
       const res = await axios.post(`http://localhost:8080/api/workrecords/duplicate/${id}`)
-      const rec = { ...res.data, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', codeToName:{} }
+      const rec = { ...res.data, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', workerHourInputs:'', codeToName:{} }
       if (rec.qualifiedQty != null && rec.hours != null) {
         rec.hourSubtotal = rec.qualifiedQty * rec.hours
       }
@@ -193,7 +208,7 @@ export default {
       if (idx !== -1) this.records.splice(idx, 1)
     },
     async processRecords(list) {
-      this.records = list.map(r => ({ ...r, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', codeToName:{} }))
+      this.records = list.map(r => ({ ...r, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', workerHourInputs:'', codeToName:{} }))
       for (const rec of this.records) {
         if (rec.qualifiedQty != null && rec.hours != null) {
           rec.hourSubtotal = rec.qualifiedQty * rec.hours
@@ -212,11 +227,19 @@ export default {
     },
     onQtyChange(rec) {
       this.computeSubtotal(rec)
-      this.computeWorkerHours(rec)
+      if (rec.workerHourInputs && rec.workerHourInputs.trim()) {
+        this.computeQtysFromHours(rec)
+      } else {
+        this.computeWorkerHours(rec)
+      }
     },
     onWorkerCodesChange(rec) {
       this.lookupWorker(rec)
-      this.computeWorkerHours(rec)
+      if (rec.workerHourInputs && rec.workerHourInputs.trim()) {
+        this.computeQtysFromHours(rec)
+      } else {
+        this.computeWorkerHours(rec)
+      }
     },
     async lookupWorker(rec) {
       const codes = rec.workerCodes ? rec.workerCodes.split(/[,\u3001\s]+/) : []
@@ -254,6 +277,7 @@ export default {
       if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
         rec.workerHours = ''
         if (!rec.workerQtys) rec.workerQtys = ''
+        rec.workerHourInputs = ''
         return
       }
       let qtys = []
@@ -265,9 +289,37 @@ export default {
         qtys = codes.map(() => share)
         rec.workerQtys = qtys.join(' ')
       }
+      const hoursArr = codes.map((_,i) => (qtys[i] || 0) * rec.hours)
       rec.workerHours = codes.map((c,i) => {
         const name = (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c
-        return `${name}:${(qtys[i] || 0) * rec.hours}`
+        return `${name}:${hoursArr[i].toFixed(2)}`
+      }).join(',')
+      rec.workerHourInputs = hoursArr.map(h => h.toFixed(2)).join(' ')
+    },
+    computeQtysFromHours(rec) {
+      const codes = rec.workerCodes ? rec.workerCodes.trim().split(/[ ,\u3001]+/) : []
+      if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
+        rec.workerHours = ''
+        rec.workerQtys = ''
+        return
+      }
+      let hours = []
+      if (rec.workerHourInputs && rec.workerHourInputs.trim()) {
+        hours = rec.workerHourInputs.trim().split(/\s+/).map(n => parseFloat(n))
+      }
+      if (hours.length !== codes.length) {
+        hours = codes.map(() => 0)
+      }
+      const total = rec.qualifiedQty * rec.hours
+      const sum = hours.reduce((a,b) => a + (b || 0), 0)
+      if (total != null && sum > total) {
+        alert('填写的工时超过总工时')
+      }
+      const qtys = hours.map(h => rec.hours ? h / rec.hours : 0)
+      rec.workerQtys = qtys.map(q => q.toFixed(2)).join(' ')
+      rec.workerHours = codes.map((c,i) => {
+        const name = (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c
+        return `${name}:${(hours[i] || 0).toFixed(2)}`
       }).join(',')
     },
     autoGrow(event) {

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -52,15 +52,15 @@
           <td>{{ rec.processCode }}</td>
           <td>{{ rec.hours }}</td>
           <td>{{ rec.planQty }}</td>
-          <td>
+          <td class="wrap-text">
             <span v-if="!rec.editing">{{ rec.workerCodes }}</span>
-            <input v-else class="form-control form-control-sm" v-model="rec.workerCodes" @blur="onWorkerCodesChange(rec)" style="width:80px" />
+            <textarea v-else class="form-control form-control-sm" rows="2" style="width:100%;" v-model="rec.workerCodes" @blur="onWorkerCodesChange(rec)"></textarea>
           </td>
           <td>
             <span v-if="!rec.editing">{{ rec.workerQtys }}</span>
             <input v-else class="form-control form-control-sm" v-model="rec.workerQtys" @input="computeWorkerHours(rec)" style="width:80px" />
           </td>
-          <td>{{ rec.workerNames }}</td>
+          <td class="wrap-text">{{ rec.workerNames }}</td>
           <td>{{ rec.workshop }}</td>
           <td>{{ rec.team }}</td>
           <td>

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -334,24 +334,23 @@ export default {
     computeWorkerHours(rec) {
       const names = rec.workerNamesList || []
       if (!names.length || rec.hours == null || rec.qualifiedQty == null) {
+        rec.workerHourVals = names.map(() => null)
         rec.workerHours = ''
         rec.workerQtys = this.formatAllocString(names)
-        rec.workerHourVals = names.map(() => null)
         return
       }
-      const qtyVals = (rec.workerQtyVals || []).map(v => (v == null || isNaN(v)) ? 0 : parseFloat(v))
-      const hasAny = qtyVals.some(v => v)
-      if (!hasAny) {
+      const qtyList = (rec.workerQtyVals || []).map(v => (v == null || isNaN(v)) ? 0 : parseFloat(v))
+      if (qtyList.every(v => v === 0)) {
         rec.workerHourVals = names.map(() => null)
         rec.workerHours = ''
-        rec.workerQtys = this.formatAllocString(names, qtyVals)
+        rec.workerQtys = this.formatAllocString(names, qtyList)
         return
       }
-      while (qtyVals.length < names.length) qtyVals.push(0)
-      const hoursArr = qtyVals.map(q => (q || 0) * rec.hours)
-      rec.workerHourVals = hoursArr
-      rec.workerHours = names.map((n,i) => `${n}:${hoursArr[i].toFixed(2)}`).join(',')
-      rec.workerQtys = this.formatAllocString(names, qtyVals)
+      while (qtyList.length < names.length) qtyList.push(0)
+      const hourList = qtyList.map(q => q * rec.hours)
+      rec.workerHourVals = hourList
+      rec.workerHours = names.map((n,i) => `${n}:${hourList[i].toFixed(2)}`).join(',')
+      rec.workerQtys = this.formatAllocString(names, qtyList)
     },
     computeQtysFromHours(rec) {
       const names = rec.workerNamesList || []
@@ -361,24 +360,23 @@ export default {
         rec.workerQtyVals = names.map(() => null)
         return
       }
-      let hours = (rec.workerHourVals || []).map(v => (v == null || isNaN(v)) ? 0 : parseFloat(v))
-      const hasAny = hours.some(v => v)
-      if (!hasAny) {
+      const hourList = (rec.workerHourVals || []).map(v => (v == null || isNaN(v)) ? 0 : parseFloat(v))
+      if (hourList.every(v => v === 0)) {
         rec.workerQtyVals = names.map(() => null)
         rec.workerHours = ''
         rec.workerQtys = this.formatAllocString(names)
         return
       }
-      while (hours.length < names.length) hours.push(0)
+      while (hourList.length < names.length) hourList.push(0)
       const total = rec.qualifiedQty * rec.hours
-      const sum = hours.reduce((a,b) => a + (b || 0), 0)
+      const sum = hourList.reduce((a,b) => a + (b || 0), 0)
       if (total != null && sum > total) {
         alert('填写的工时超过总工时')
       }
-      const qtys = hours.map(h => rec.hours ? h / rec.hours : 0)
-      rec.workerQtyVals = qtys
-      rec.workerQtys = this.formatAllocString(names, qtys)
-      rec.workerHours = names.map((n,i) => `${n}:${(hours[i] || 0).toFixed(2)}`).join(',')
+      const qtyList = hourList.map(h => rec.hours ? h / rec.hours : 0)
+      rec.workerQtyVals = qtyList
+      rec.workerQtys = this.formatAllocString(names, qtyList)
+      rec.workerHours = names.map((n,i) => `${n}:${hourList[i].toFixed(2)}`).join(',')
     },
     parseAllocValues(str) {
       if (!str) return []

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -66,13 +66,22 @@
           </td>
           <td>
             <span v-if="!rec.editing">{{ rec.workerQtys }}</span>
-            <input
-              v-else
-              class="form-control form-control-sm"
-              v-model="rec.workerQtys"
-              @input="computeWorkerHours(rec)"
-              style="width:80px"
-            />
+            <div v-else class="d-flex flex-wrap">
+              <div
+                v-for="(name, idx) in rec.workerNamesList"
+                :key="idx"
+                class="me-1 mb-1"
+              >
+                <input
+                  type="number"
+                  class="form-control form-control-sm"
+                  style="width:70px"
+                  v-model.number="rec.workerQtyVals[idx]"
+                  :placeholder="name"
+                  @input="onQtyFieldsInput(rec)"
+                />
+              </div>
+            </div>
           </td>
           <td class="wrap-text">{{ rec.workerNames }}</td>
           <td class="wrap-text">{{ rec.workshop }}</td>
@@ -84,13 +93,22 @@
           <td>{{ rec.hourSubtotal }}</td>
           <td class="wrap-text">
             <span v-if="!rec.editing">{{ rec.workerHours }}</span>
-            <input
-              v-else
-              class="form-control form-control-sm"
-              v-model="rec.workerHourInputs"
-              @input="computeQtysFromHours(rec)"
-              style="width:100px"
-            />
+            <div v-else class="d-flex flex-wrap">
+              <div
+                v-for="(name, idx) in rec.workerNamesList"
+                :key="idx"
+                class="me-1 mb-1"
+              >
+                <input
+                  type="number"
+                  class="form-control form-control-sm"
+                  style="width:70px"
+                  v-model.number="rec.workerHourVals[idx]"
+                  :placeholder="name"
+                  @input="onHourFieldsInput(rec)"
+                />
+              </div>
+            </div>
           </td>
           <td v-if="!viewOnly">
             <template v-if="!rec.editing">
@@ -193,8 +211,19 @@ export default {
       }
       if (!this.records.length) return
       const id = this.records[0].id
-      const res = await axios.post(`http://localhost:8080/api/workrecords/duplicate/${id}`)
-      const rec = { ...res.data, editing: false, workshop:'', team:'', workerQtys:'', workerHours:'', workerHourInputs:'', codeToName:{} }
+        const res = await axios.post(`http://localhost:8080/api/workrecords/duplicate/${id}`)
+        const rec = {
+          ...res.data,
+          editing: false,
+          workshop: '',
+          team: '',
+          workerQtys: '',
+          workerHours: '',
+          workerQtyVals: [],
+          workerHourVals: [],
+          workerNamesList: [],
+          codeToName: {}
+        }
       if (rec.qualifiedQty != null && rec.hours != null) {
         rec.hourSubtotal = rec.qualifiedQty * rec.hours
       }
@@ -215,7 +244,9 @@ export default {
         team: '',
         workerQtys: r.workerQtys || '',
         workerHours: '',
-        workerHourInputs: '',
+        workerQtyVals: this.parseAllocValues(r.workerQtys),
+        workerHourVals: [],
+        workerNamesList: [],
         codeToName: {}
       }))
       for (const rec of this.records) {
@@ -236,7 +267,7 @@ export default {
     },
     onQtyChange(rec) {
       this.computeSubtotal(rec)
-      if (this.parseAllocValues(rec.workerHourInputs).some(v => v != null)) {
+      if (rec.workerHourVals.some(v => v != null && v !== '' && !isNaN(v))) {
         this.computeQtysFromHours(rec)
       } else {
         this.computeWorkerHours(rec)
@@ -244,11 +275,17 @@ export default {
     },
     onWorkerCodesChange(rec) {
       this.lookupWorker(rec)
-      if (this.parseAllocValues(rec.workerHourInputs).some(v => v != null)) {
+      if (rec.workerHourVals.some(v => v != null && v !== '' && !isNaN(v))) {
         this.computeQtysFromHours(rec)
       } else {
         this.computeWorkerHours(rec)
       }
+    },
+    onQtyFieldsInput(rec) {
+      this.computeWorkerHours(rec)
+    },
+    onHourFieldsInput(rec) {
+      this.computeQtysFromHours(rec)
     },
     async lookupWorker(rec) {
       const codes = rec.workerCodes ? rec.workerCodes.split(/[,\u3001\s]+/) : []
@@ -280,61 +317,66 @@ export default {
       rec.workerNames = names.join(',')
       rec.workshop = Array.from(workshops).join(',')
       rec.team = Array.from(teams).join(',')
-      const qtyVals = this.parseAllocValues(rec.workerQtys)
-      const hourVals = this.parseAllocValues(rec.workerHourInputs)
-      rec.workerQtys = this.formatAllocString(names, qtyVals.length === names.length ? qtyVals : undefined)
-      rec.workerHourInputs = this.formatAllocString(names, hourVals.length === names.length ? hourVals : undefined)
+      rec.workerNamesList = names
+      const qtyVals = rec.workerQtyVals && rec.workerQtyVals.length
+        ? rec.workerQtyVals
+        : this.parseAllocValues(rec.workerQtys)
+      const hourVals = rec.workerHourVals && rec.workerHourVals.length
+        ? rec.workerHourVals
+        : []
+      while (qtyVals.length < names.length) qtyVals.push(null)
+      while (hourVals.length < names.length) hourVals.push(null)
+      rec.workerQtyVals = qtyVals
+      rec.workerHourVals = hourVals
+      rec.workerQtys = this.formatAllocString(names, qtyVals)
+      rec.workerHours = this.formatAllocString(names, hourVals)
     },
     computeWorkerHours(rec) {
-      const codes = rec.workerCodes
-        ? rec.workerCodes.trim().split(/[,\u3001\s]+/)
-        : []
-      const names = codes.map(c => (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c)
-      if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
+      const names = rec.workerNamesList || []
+      if (!names.length || rec.hours == null || rec.qualifiedQty == null) {
         rec.workerHours = ''
-        rec.workerHourInputs = this.formatAllocString(names)
         rec.workerQtys = this.formatAllocString(names)
+        rec.workerHourVals = names.map(() => null)
         return
       }
-      let qtyVals = this.parseAllocValues(rec.workerQtys)
-      const hasAny = qtyVals.some(v => v != null)
+      const qtyVals = (rec.workerQtyVals || []).map(v => (v == null || isNaN(v)) ? 0 : parseFloat(v))
+      const hasAny = qtyVals.some(v => v)
       if (!hasAny) {
-        rec.workerHourInputs = this.formatAllocString(names)
+        rec.workerHourVals = names.map(() => null)
         rec.workerHours = ''
+        rec.workerQtys = this.formatAllocString(names, qtyVals)
         return
       }
-      while (qtyVals.length < codes.length) qtyVals.push(0)
-      qtyVals = qtyVals.map(v => (v == null || isNaN(v)) ? 0 : v)
+      while (qtyVals.length < names.length) qtyVals.push(0)
       const hoursArr = qtyVals.map(q => (q || 0) * rec.hours)
+      rec.workerHourVals = hoursArr
       rec.workerHours = names.map((n,i) => `${n}:${hoursArr[i].toFixed(2)}`).join(',')
-      rec.workerHourInputs = this.formatAllocString(names, hoursArr)
       rec.workerQtys = this.formatAllocString(names, qtyVals)
     },
     computeQtysFromHours(rec) {
-      const codes = rec.workerCodes
-        ? rec.workerCodes.trim().split(/[,\u3001\s]+/)
-        : []
-      const names = codes.map(c => (rec.codeToName && rec.codeToName[c]) ? rec.codeToName[c] : c)
-      if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
+      const names = rec.workerNamesList || []
+      if (!names.length || rec.hours == null || rec.qualifiedQty == null) {
         rec.workerHours = ''
         rec.workerQtys = this.formatAllocString(names)
+        rec.workerQtyVals = names.map(() => null)
         return
       }
-      let hours = this.parseAllocValues(rec.workerHourInputs)
-      const hasAny = hours.some(v => v != null)
+      let hours = (rec.workerHourVals || []).map(v => (v == null || isNaN(v)) ? 0 : parseFloat(v))
+      const hasAny = hours.some(v => v)
       if (!hasAny) {
-        rec.workerQtys = this.formatAllocString(names)
+        rec.workerQtyVals = names.map(() => null)
         rec.workerHours = ''
+        rec.workerQtys = this.formatAllocString(names)
         return
       }
-      while (hours.length < codes.length) hours.push(0)
-      hours = hours.map(v => (v == null || isNaN(v)) ? 0 : v)
+      while (hours.length < names.length) hours.push(0)
       const total = rec.qualifiedQty * rec.hours
       const sum = hours.reduce((a,b) => a + (b || 0), 0)
       if (total != null && sum > total) {
         alert('填写的工时超过总工时')
       }
       const qtys = hours.map(h => rec.hours ? h / rec.hours : 0)
+      rec.workerQtyVals = qtys
       rec.workerQtys = this.formatAllocString(names, qtys)
       rec.workerHours = names.map((n,i) => `${n}:${(hours[i] || 0).toFixed(2)}`).join(',')
     },

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -282,7 +282,9 @@ export default {
       rec.team = Array.from(teams).join(',')
     },
     computeWorkerHours(rec) {
-      const codes = rec.workerCodes ? rec.workerCodes.trim().split(/[ ,\u3001]+/) : []
+      const codes = rec.workerCodes
+        ? rec.workerCodes.trim().split(/[,\u3001\s]+/)
+        : []
       if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
         rec.workerHours = ''
         if (!rec.workerQtys) rec.workerQtys = ''
@@ -306,7 +308,9 @@ export default {
       rec.workerHourInputs = hoursArr.map(h => h.toFixed(2)).join(' ')
     },
     computeQtysFromHours(rec) {
-      const codes = rec.workerCodes ? rec.workerCodes.trim().split(/[ ,\u3001]+/) : []
+      const codes = rec.workerCodes
+        ? rec.workerCodes.trim().split(/[,\u3001\s]+/)
+        : []
       if (!codes.length || rec.hours == null || rec.qualifiedQty == null) {
         rec.workerHours = ''
         rec.workerQtys = ''

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -54,7 +54,15 @@
           <td>{{ rec.planQty }}</td>
           <td class="wrap-text">
             <span v-if="!rec.editing">{{ rec.workerCodes }}</span>
-            <textarea v-else class="form-control form-control-sm" rows="2" style="width:100%;" v-model="rec.workerCodes" @blur="onWorkerCodesChange(rec)"></textarea>
+            <textarea
+              v-else
+              class="form-control form-control-sm auto-grow"
+              style="width:100%;"
+              v-model="rec.workerCodes"
+              @focus="autoGrow"
+              @input="autoGrow"
+              @blur="onWorkerCodesChange(rec)"
+            ></textarea>
           </td>
           <td>
             <span v-if="!rec.editing">{{ rec.workerQtys }}</span>
@@ -253,6 +261,12 @@ export default {
         rec.workerQtys = qtys.join(' ')
       }
       rec.workerHours = codes.map((c,i)=> `${c}:${(qtys[i]||0)*rec.hours}` ).join(',')
+    },
+    autoGrow(event) {
+      const el = event.target
+      if (!el) return
+      el.style.height = 'auto'
+      el.style.height = el.scrollHeight + 'px'
     }
   }
 }

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -228,6 +228,8 @@ export default {
       if (rec.workerCodes) await this.lookupWorker(rec)
       this.computeWorkerHours(rec)
       this.records.push(rec)
+      // reload from backend to ensure state consistent
+      this.searchByBarcode()
     },
     async deleteRecord(rec) {
       if (!confirm('确定删除这条记录?')) return
@@ -235,6 +237,8 @@ export default {
         await axios.delete(`http://localhost:8080/api/workrecords/${rec.id}`)
         const idx = this.records.indexOf(rec)
         if (idx !== -1) this.records.splice(idx, 1)
+        // ensure UI reflects backend state
+        this.searchByBarcode()
       } catch (e) {
         console.error(e)
         alert('删除失败')

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -87,7 +87,7 @@
           <td class="wrap-text">{{ rec.team }}</td>
           <td>
             <span v-if="!rec.editing">{{ rec.qualifiedQty }}</span>
-            <input v-else type="number" class="form-control form-control-sm" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" style="width:80px" />
+            <input v-else type="number" step="0.01" class="form-control form-control-sm" v-model.number="rec.qualifiedQty" @input="onQtyChange(rec)" style="width:80px" />
           </td>
           <td>{{ rec.hourSubtotal }}</td>
           <td class="wrap-text">
@@ -390,7 +390,8 @@ export default {
       if (!str) return []
       return str.trim().split(/[\s,]+/).map(seg => {
         if (!seg) return null
-        const idx = seg.indexOf(':')
+        let idx = seg.indexOf(':')
+        if (idx < 0) idx = seg.indexOf('：')
         const numStr = idx >= 0 ? seg.slice(idx + 1) : seg
         if (numStr === '') return null
         const v = parseFloat(numStr)

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -6,7 +6,7 @@
       <button class="btn btn-outline-primary" @click="parse" :disabled="!file">解析</button>
       <select class="form-select" style="max-width:180px" v-model="selectedFileId">
         <option value="" disabled>选择历史文件</option>
-        <option v-for="f in files" :key="f.id" :value="f.id">{{ f.fileName }}</option>
+        <option v-for="f in files" :key="f.id" :value="f.id">{{ f.fileName }} ({{ f.uploadTime ? f.uploadTime.slice(0,10) : '' }})</option>
       </select>
       <button class="btn btn-outline-secondary" @click="load" :disabled="!selectedFileId">加载</button>
       <button class="btn btn-outline-danger" @click="remove" :disabled="!selectedFileId">删除</button>


### PR DESCRIPTION
## Summary
- allow table cells to wrap text without widening the layout
- show worker codes in a textarea so long codes wrap in RecordScanner
- also wrap worker names

## Testing
- `npm install --prefix frontend`
- `npm run --prefix frontend build`


------
https://chatgpt.com/codex/tasks/task_e_6886c525ff10832c9939b5ee254a41f2