### PR TITLE
Add operation log page

### DIFF
--- a/backend/src/main/java/com/example/worktime/controller/AuthController.java
+++ b/backend/src/main/java/com/example/worktime/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.worktime.controller;
 
 import com.example.worktime.model.User;
 import com.example.worktime.repository.UserRepository;
+import com.example.worktime.service.OperationLogService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -11,9 +12,11 @@ import org.springframework.web.server.ResponseStatusException;
 @CrossOrigin
 public class AuthController {
     private final UserRepository repository;
+    private final OperationLogService logService;
 
-    public AuthController(UserRepository repository) {
+    public AuthController(UserRepository repository, OperationLogService logService) {
         this.repository = repository;
+        this.logService = logService;
     }
 
     @PostMapping("/login")
@@ -21,5 +24,6 @@ public class AuthController {
         if (!repository.findByUsernameAndPassword(user.getUsername(), user.getPassword()).isPresent()) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "账号或密码错误");
         }
+        logService.log(user.getUsername(), "登录", null);
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
+++ b/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
@@ -1,0 +1,23 @@
+package com.example.worktime.controller;
+
+import com.example.worktime.model.OperationLog;
+import com.example.worktime.repository.OperationLogRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/logs")
+@CrossOrigin
+public class OperationLogController {
+    private final OperationLogRepository repository;
+
+    public OperationLogController(OperationLogRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<OperationLog> logs(@RequestHeader("X-User") String username) {
+        return repository.findByUsernameOrderByTimestampDesc(username);
+    }
+}

--- a/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
+++ b/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
@@ -3,6 +3,7 @@ package com.example.worktime.controller;
 import com.example.worktime.model.UploadedFile;
 import com.example.worktime.repository.UploadedFileRepository;
 import com.example.worktime.repository.WorkRecordRepository;
+import com.example.worktime.service.OperationLogService;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,10 +15,13 @@ import java.util.List;
 public class UploadedFileController {
     private final UploadedFileRepository repository;
     private final WorkRecordRepository recordRepository;
+    private final OperationLogService logService;
 
-    public UploadedFileController(UploadedFileRepository repository, WorkRecordRepository recordRepository) {
+    public UploadedFileController(UploadedFileRepository repository, WorkRecordRepository recordRepository,
+                                 OperationLogService logService) {
         this.repository = repository;
         this.recordRepository = recordRepository;
+        this.logService = logService;
     }
 
     @GetMapping
@@ -27,7 +31,11 @@ public class UploadedFileController {
 
     @DeleteMapping("/{id}")
     @Transactional
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
+        UploadedFile file = repository.findById(id).orElse(null);
+        long cnt = recordRepository.countByFileId(id);
         repository.deleteById(id);
+        String name = file != null ? file.getFileName() : String.valueOf(id);
+        logService.log(user, "删除文件 " + name, "records=" + cnt);
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
+++ b/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
@@ -28,7 +28,6 @@ public class UploadedFileController {
     @DeleteMapping("/{id}")
     @Transactional
     public void delete(@PathVariable Long id) {
-        recordRepository.deleteByFileId(id);
         repository.deleteById(id);
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -4,6 +4,7 @@ import com.example.worktime.model.WorkRecord;
 import com.example.worktime.model.UploadedFile;
 import com.example.worktime.repository.WorkRecordRepository;
 import com.example.worktime.repository.UploadedFileRepository;
+import com.example.worktime.service.OperationLogService;
 import com.example.worktime.service.ProcessCodeService;
 import com.example.worktime.service.WorkerService;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,13 +37,16 @@ public class WorkRecordController {
     private final ProcessCodeService processService;
     private final WorkerService workerService;
     private final UploadedFileRepository fileRepository;
+    private final OperationLogService logService;
 
     public WorkRecordController(WorkRecordRepository repository, ProcessCodeService processService,
-                                WorkerService workerService, UploadedFileRepository fileRepository) {
+                                WorkerService workerService, UploadedFileRepository fileRepository,
+                                OperationLogService logService) {
         this.repository = repository;
         this.processService = processService;
         this.workerService = workerService;
         this.fileRepository = fileRepository;
+        this.logService = logService;
     }
 
     @GetMapping
@@ -234,7 +238,8 @@ public class WorkRecordController {
 
     @PutMapping("/{id}")
     @Transactional
-    public WorkRecord update(@PathVariable Long id, @RequestBody WorkRecord record) {
+    public WorkRecord update(@PathVariable Long id, @RequestBody WorkRecord record,
+                             @RequestHeader("X-User") String user) {
         WorkRecord existing = repository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "record not found"));
         record.setId(id);
@@ -245,11 +250,13 @@ public class WorkRecordController {
         if (record.getBarcodeImage() == null) record.setBarcodeImage(existing.getBarcodeImage());
         prepare(record);
         if (record.getQualifiedQty() != null) record.setFilled(true);
-        return repository.save(record);
+        WorkRecord updated = repository.save(record);
+        logService.log(user, "更新记录 " + id, null);
+        return updated;
     }
 
     @PostMapping("/duplicate/{id}")
-    public WorkRecord duplicate(@PathVariable Long id) {
+    public WorkRecord duplicate(@PathVariable Long id, @RequestHeader("X-User") String user) {
         WorkRecord src = repository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "record not found"));
         WorkRecord copy = new WorkRecord();
@@ -269,19 +276,23 @@ public class WorkRecordController {
         copy.setSupplemental(true);
         copy.setFilled(false);
         prepare(copy);
-        return repository.save(copy);
+        WorkRecord saved = repository.save(copy);
+        logService.log(user, "复制记录 " + id, "newId=" + saved.getId());
+        return saved;
     }
 
     @DeleteMapping("/{id}")
     @Transactional
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
         repository.deleteById(id);
         repository.flush();
+        logService.log(user, "删除记录 " + id, null);
     }
 
     @PostMapping
     @org.springframework.transaction.annotation.Transactional
-    public List<WorkRecord> save(@RequestParam("fileId") Long fileId, @RequestBody List<WorkRecord> records) {
+    public List<WorkRecord> save(@RequestParam("fileId") Long fileId, @RequestBody List<WorkRecord> records,
+                                 @RequestHeader("X-User") String user) {
         UploadedFile file = fileRepository.findById(fileId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "无效文件"));
         for (WorkRecord r : records) {
@@ -293,12 +304,14 @@ public class WorkRecordController {
         java.util.List<WorkRecord> saved = repository.saveAll(records);
         repository.flush();
         System.out.println("Saved records: " + saved.size());
+        logService.log(user, "新增记录" , "fileId=" + fileId + " count=" + saved.size());
         return saved;
     }
 
     @PostMapping("/parse")
     @Transactional
-    public Map<String, Object> parse(@RequestParam("file") MultipartFile file) throws IOException {
+    public Map<String, Object> parse(@RequestParam("file") MultipartFile file,
+                                     @RequestHeader("X-User") String user) throws IOException {
         UploadedFile uf = new UploadedFile();
         uf.setFileName(file.getOriginalFilename());
         uf.setData(file.getBytes());
@@ -311,6 +324,7 @@ public class WorkRecordController {
         result.put("fileId", uf.getId());
         result.put("records", records);
         System.out.println("Parsed records: " + records.size() + " for file " + uf.getId());
+        logService.log(user, "上传文件 " + uf.getFileName(), "records=" + records.size());
         return result;
     }
 

--- a/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
+++ b/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
@@ -1,0 +1,36 @@
+package com.example.worktime.filter;
+
+import com.example.worktime.model.OperationLog;
+import com.example.worktime.repository.OperationLogRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+public class OperationLogFilter extends OncePerRequestFilter {
+    private final OperationLogRepository repository;
+
+    public OperationLogFilter(OperationLogRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String user = request.getHeader("X-User");
+        if (user != null && !request.getRequestURI().startsWith("/api/logs")) {
+            OperationLog log = new OperationLog();
+            log.setUsername(user);
+            log.setAction(request.getMethod() + " " + request.getRequestURI());
+            log.setTimestamp(LocalDateTime.now());
+            repository.save(log);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
+++ b/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
@@ -24,13 +24,14 @@ public class OperationLogFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String user = request.getHeader("X-User");
-        if (user != null && !request.getRequestURI().startsWith("/api/logs")) {
+        filterChain.doFilter(request, response);
+        if (user != null && request.getAttribute("operationLogged") == null
+                && !request.getRequestURI().startsWith("/api/logs")) {
             OperationLog log = new OperationLog();
             log.setUsername(user);
             log.setAction(request.getMethod() + " " + request.getRequestURI());
             log.setTimestamp(LocalDateTime.now());
             repository.save(log);
         }
-        filterChain.doFilter(request, response);
     }
 }

--- a/backend/src/main/java/com/example/worktime/model/OperationLog.java
+++ b/backend/src/main/java/com/example/worktime/model/OperationLog.java
@@ -18,6 +18,9 @@ public class OperationLog {
 
     private LocalDateTime timestamp;
 
+    @Lob
+    private String details;
+
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 
@@ -29,4 +32,7 @@ public class OperationLog {
 
     public LocalDateTime getTimestamp() { return timestamp; }
     public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+
+    public String getDetails() { return details; }
+    public void setDetails(String details) { this.details = details; }
 }

--- a/backend/src/main/java/com/example/worktime/model/OperationLog.java
+++ b/backend/src/main/java/com/example/worktime/model/OperationLog.java
@@ -1,0 +1,32 @@
+package com.example.worktime.model;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Entity representing a user operation log entry.
+ */
+@Entity
+public class OperationLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String action;
+
+    private LocalDateTime timestamp;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getAction() { return action; }
+    public void setAction(String action) { this.action = action; }
+
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+}

--- a/backend/src/main/java/com/example/worktime/repository/OperationLogRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/OperationLogRepository.java
@@ -1,0 +1,10 @@
+package com.example.worktime.repository;
+
+import com.example.worktime.model.OperationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OperationLogRepository extends JpaRepository<OperationLog, Long> {
+    List<OperationLog> findByUsernameOrderByTimestampDesc(String username);
+}

--- a/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
@@ -15,4 +15,6 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
                                                 @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
 
     void deleteByFileId(Long fileId);
+
+    long countByFileId(Long fileId);
 }

--- a/backend/src/main/java/com/example/worktime/service/OperationLogService.java
+++ b/backend/src/main/java/com/example/worktime/service/OperationLogService.java
@@ -1,0 +1,34 @@
+package com.example.worktime.service;
+
+import com.example.worktime.model.OperationLog;
+import com.example.worktime.repository.OperationLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+
+@Service
+public class OperationLogService {
+    private final OperationLogRepository repository;
+
+    public OperationLogService(OperationLogRepository repository) {
+        this.repository = repository;
+    }
+
+    public void log(String username, String action, String details) {
+        if (username == null) return;
+        OperationLog log = new OperationLog();
+        log.setUsername(username);
+        log.setAction(action);
+        log.setDetails(details);
+        log.setTimestamp(LocalDateTime.now());
+        repository.save(log);
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs != null) {
+            HttpServletRequest req = attrs.getRequest();
+            if (req != null) req.setAttribute("operationLogged", true);
+        }
+    }
+}

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -76,7 +76,7 @@ CREATE TABLE IF NOT EXISTS work_record (
     file_id BIGINT,
     supplemental BOOLEAN,
     CONSTRAINT fk_work_record_file FOREIGN KEY (file_id)
-        REFERENCES uploaded_file(id)
+        REFERENCES uploaded_file(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS operation_log (

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -78,3 +78,10 @@ CREATE TABLE IF NOT EXISTS work_record (
     CONSTRAINT fk_work_record_file FOREIGN KEY (file_id)
         REFERENCES uploaded_file(id)
 );
+
+CREATE TABLE IF NOT EXISTS operation_log (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255),
+    action VARCHAR(255),
+    timestamp DATETIME
+);

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -83,5 +83,6 @@ CREATE TABLE IF NOT EXISTS operation_log (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     username VARCHAR(255),
     action VARCHAR(255),
-    timestamp DATETIME
+    timestamp DATETIME,
+    details TEXT
 );

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,6 +10,7 @@
             <li class="nav-item"><router-link class="nav-link" to="/records">扫码录入</router-link></li>
             <li class="nav-item"><router-link class="nav-link" to="/workers">人员管理</router-link></li>
             <li class="nav-item"><router-link class="nav-link" to="/processes">工序代码</router-link></li>
+            <li class="nav-item"><router-link class="nav-link" to="/logs">操作记录</router-link></li>
             <li class="nav-item"><a href="#" class="nav-link" @click.prevent="logout">退出登录</a></li>
           </ul>
         </div>
@@ -33,14 +34,16 @@ export default {
     this.loggedIn = localStorage.getItem('loggedIn') === 'true'
   },
   methods: {
-    onLogin() {
+   onLogin() {
       this.loggedIn = true
       localStorage.setItem('loggedIn','true')
-    },
-    logout() {
+      // keep username from LoginPage
+   },
+   logout() {
       this.loggedIn = false
       localStorage.removeItem('loggedIn')
-    },
+      localStorage.removeItem('username')
+   },
     onSaved() {
       const v = this.$refs.view
       if (v && v.fetch) v.fetch()

--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -28,6 +28,7 @@ export default {
           password: this.password
         })
         localStorage.setItem('loggedIn','true')
+        localStorage.setItem('username', this.username)
         this.$emit('logged-in')
       } catch (e) {
         this.error = '登录失败'

--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -23,10 +23,14 @@ export default {
   methods: {
     async login() {
       try {
-        await axios.post('http://localhost:8080/api/auth/login', {
-          username: this.username,
-          password: this.password
-        })
+        await axios.post(
+          'http://localhost:8080/api/auth/login',
+          {
+            username: this.username,
+            password: this.password
+          },
+          { headers: { 'X-User': this.username } }
+        )
         localStorage.setItem('loggedIn','true')
         localStorage.setItem('username', this.username)
         this.$emit('logged-in')

--- a/frontend/src/components/OperationLog.vue
+++ b/frontend/src/components/OperationLog.vue
@@ -24,7 +24,14 @@ export default {
   created() { this.fetchLogs() },
   methods: {
     async fetchLogs() {
-      const res = await axios.get('http://localhost:8080/api/logs')
+      const user = localStorage.getItem('username')
+      if (!user) {
+        this.logs = []
+        return
+      }
+      const res = await axios.get('http://localhost:8080/api/logs', {
+        headers: { 'X-User': user }
+      })
       this.logs = res.data
     }
   }

--- a/frontend/src/components/OperationLog.vue
+++ b/frontend/src/components/OperationLog.vue
@@ -6,12 +6,12 @@
         <tr><th>时间</th><th>操作</th></tr>
       </thead>
       <tbody>
-        <template v-for="log in logs" :key="log.id">
-          <tr @click="log.show = !log.show" style="cursor:pointer">
+        <template v-for="log in logs">
+          <tr :key="log.id" @click="log.show = !log.show" style="cursor:pointer">
             <td>{{ log.timestamp.replace('T',' ').slice(0,19) }}</td>
             <td class="wrap-text">{{ log.action }}</td>
           </tr>
-          <tr v-if="log.show">
+          <tr v-if="log.show" :key="log.id + '-details'">
             <td colspan="2" class="pre-wrap">{{ log.details }}</td>
           </tr>
         </template>

--- a/frontend/src/components/OperationLog.vue
+++ b/frontend/src/components/OperationLog.vue
@@ -1,0 +1,32 @@
+<template>
+  <section class="section-card">
+    <h2 class="h5">操作记录</h2>
+    <table class="table table-bordered table-sm table-striped">
+      <thead>
+        <tr><th>时间</th><th>操作</th></tr>
+      </thead>
+      <tbody>
+        <tr v-for="log in logs" :key="log.id">
+          <td>{{ log.timestamp.replace('T',' ').slice(0,19) }}</td>
+          <td class="wrap-text">{{ log.action }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>
+
+<script>
+import axios from 'axios'
+export default {
+  data() {
+    return { logs: [] }
+  },
+  created() { this.fetchLogs() },
+  methods: {
+    async fetchLogs() {
+      const res = await axios.get('http://localhost:8080/api/logs')
+      this.logs = res.data
+    }
+  }
+}
+</script>

--- a/frontend/src/components/OperationLog.vue
+++ b/frontend/src/components/OperationLog.vue
@@ -6,10 +6,15 @@
         <tr><th>时间</th><th>操作</th></tr>
       </thead>
       <tbody>
-        <tr v-for="log in logs" :key="log.id">
-          <td>{{ log.timestamp.replace('T',' ').slice(0,19) }}</td>
-          <td class="wrap-text">{{ log.action }}</td>
-        </tr>
+        <template v-for="log in logs" :key="log.id">
+          <tr @click="log.show = !log.show" style="cursor:pointer">
+            <td>{{ log.timestamp.replace('T',' ').slice(0,19) }}</td>
+            <td class="wrap-text">{{ log.action }}</td>
+          </tr>
+          <tr v-if="log.show">
+            <td colspan="2" class="pre-wrap">{{ log.details }}</td>
+          </tr>
+        </template>
       </tbody>
     </table>
   </section>
@@ -37,3 +42,7 @@ export default {
   }
 }
 </script>
+
+<style>
+.pre-wrap { white-space: pre-wrap; }
+</style>

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -104,7 +104,7 @@ export default {
     },
     async remove() {
       if (!this.selectedFileId) return
-      if (!confirm('删除后不可恢复，确定删除?')) return
+      if (!confirm('删除该文件及其所有记录，确定删除?')) return
       this.loading = true
       await axios.delete(`http://localhost:8080/api/files/${this.selectedFileId}`)
       this.loading = false

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,6 +2,13 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import './assets/style.css'
+import axios from 'axios'
+
+axios.interceptors.request.use(config => {
+  const user = localStorage.getItem('username')
+  if (user) config.headers['X-User'] = user
+  return config
+})
 
 new Vue({
   router,

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -4,6 +4,7 @@ import RecordUpload from './components/RecordUpload.vue'
 import RecordScanner from './components/RecordScanner.vue'
 import WorkerManager from './components/WorkerManager.vue'
 import ProcessManager from './components/ProcessManager.vue'
+import OperationLog from './components/OperationLog.vue'
 
 Vue.use(Router)
 
@@ -13,6 +14,7 @@ export default new Router({
     { path: '/upload', component: RecordUpload },
     { path: '/records', component: RecordScanner },
     { path: '/workers', component: WorkerManager },
-    { path: '/processes', component: ProcessManager }
+    { path: '/processes', component: ProcessManager },
+    { path: '/logs', component: OperationLog }
   ]
 })


### PR DESCRIPTION
## Summary
- log user operations server-side
- expose log retrieval endpoint
- send username header from frontend
- store username on login and clear on logout
- add a new OperationLog page and route
- update navigation to access the new page

## Testing
- `mvn -f backend/pom.xml -q package` *(fails: Non-resolvable parent POM)*
- `npm install --prefix frontend`
- `npm run --prefix frontend build`

------
https://chatgpt.com/codex/tasks/task_e_6887295d0024832c9768bc638b210b71