### PR TITLE
Rename work-hour labels and allow plan quantity edits

### DIFF
--- a/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
+++ b/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
@@ -17,7 +17,7 @@ public class OperationLogController {
     }
 
     @GetMapping
-    public List<OperationLog> logs(@RequestHeader("X-User") String username) {
-        return repository.findByUsernameOrderByTimestampDesc(username);
+    public List<OperationLog> logs() {
+        return repository.findAllByOrderByTimestampDesc();
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
+++ b/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
@@ -2,6 +2,7 @@ package com.example.worktime.controller;
 
 import com.example.worktime.model.ProcessCode;
 import com.example.worktime.repository.ProcessCodeRepository;
+import com.example.worktime.service.OperationLogService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -13,9 +14,11 @@ import java.util.List;
 @CrossOrigin
 public class ProcessCodeController {
     private final ProcessCodeRepository repository;
+    private final OperationLogService logService;
 
-    public ProcessCodeController(ProcessCodeRepository repository) {
+    public ProcessCodeController(ProcessCodeRepository repository, OperationLogService logService) {
         this.repository = repository;
+        this.logService = logService;
     }
 
     @GetMapping
@@ -38,21 +41,26 @@ public class ProcessCodeController {
     }
 
     @PostMapping
-    public ProcessCode create(@RequestBody ProcessCode pc) {
+    public ProcessCode create(@RequestBody ProcessCode pc, @RequestHeader("X-User") String user) {
         validate(pc);
-        return repository.save(pc);
+        ProcessCode saved = repository.save(pc);
+        logService.log(user, "新增工序 " + pc.getName(), "id=" + saved.getId());
+        return saved;
     }
 
     @PutMapping("/{id}")
-    public ProcessCode update(@PathVariable Long id, @RequestBody ProcessCode pc) {
+    public ProcessCode update(@PathVariable Long id, @RequestBody ProcessCode pc, @RequestHeader("X-User") String user) {
         pc.setId(id);
         validate(pc);
-        return repository.save(pc);
+        ProcessCode saved = repository.save(pc);
+        logService.log(user, "更新工序 " + id, null);
+        return saved;
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
         repository.deleteById(id);
+        logService.log(user, "删除工序 " + id, null);
     }
 
     private void validate(ProcessCode pc) {

--- a/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
+++ b/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
@@ -34,6 +34,7 @@ public class UploadedFileController {
     public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
         UploadedFile file = repository.findById(id).orElse(null);
         long cnt = recordRepository.countByFileId(id);
+        recordRepository.deleteByFileId(id);
         repository.deleteById(id);
         String name = file != null ? file.getFileName() : String.valueOf(id);
         logService.log(user, "删除文件 " + name, "records=" + cnt);

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -27,6 +27,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.*;
 
 @RestController
@@ -84,6 +87,45 @@ public class WorkRecordController {
         java.time.LocalDateTime end = start.plusDays(1);
         List<WorkRecord> list = repository.findByUploadDate(start, end);
         exportList(list, "records_" + date.toString() + ".xlsx", response);
+    }
+
+    @GetMapping("/natural-month/{year}/{month}/export")
+    @Transactional(readOnly = true)
+    public void exportByNaturalMonth(@PathVariable int year,
+                                     @PathVariable int month,
+                                     HttpServletResponse response) throws IOException {
+        YearMonth ym;
+        try {
+            ym = YearMonth.of(year, month);
+        } catch (DateTimeException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "无效的月份");
+        }
+        List<WorkRecord> filled = repository.findByFilledTrue();
+        List<WorkRecord> filtered = new ArrayList<>();
+        for (WorkRecord record : filled) {
+            YearMonth recordMonth = determineNaturalMonth(record);
+            if (ym.equals(recordMonth)) {
+                filtered.add(record);
+            }
+        }
+        String fileName = String.format("records_%s.xlsx", ym);
+        exportList(filtered, fileName, response);
+    }
+
+    private YearMonth determineNaturalMonth(WorkRecord record) {
+        LocalDate date = null;
+        if (record.getEndTime() != null) {
+            date = record.getEndTime().toLocalDate();
+        } else if (record.getStartTime() != null) {
+            date = record.getStartTime().toLocalDate();
+        } else if (record.getFile() != null && record.getFile().getUploadTime() != null) {
+            date = record.getFile().getUploadTime().toLocalDate();
+        }
+        if (date == null) return null;
+        if (date.getDayOfMonth() >= 26) {
+            date = date.plusMonths(1);
+        }
+        return YearMonth.from(date);
     }
 
     private java.util.List<String> splitWorkers(String codes) {

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -73,7 +73,8 @@ public class WorkRecordController {
     @GetMapping("/file/{fileId}/export")
     public void exportFilled(@PathVariable Long fileId, HttpServletResponse response) throws IOException {
         List<WorkRecord> list = repository.findByFileIdAndFilledTrue(fileId);
-        exportList(list, response);
+        String name = fileRepository.findById(fileId).map(UploadedFile::getFileName).orElse("records.xlsx");
+        exportList(list, name, response);
     }
 
     @GetMapping("/date/{date}/export")
@@ -82,7 +83,7 @@ public class WorkRecordController {
         java.time.LocalDateTime start = date.atStartOfDay();
         java.time.LocalDateTime end = start.plusDays(1);
         List<WorkRecord> list = repository.findByUploadDate(start, end);
-        exportList(list, response);
+        exportList(list, "records_" + date.toString() + ".xlsx", response);
     }
 
     private java.util.List<String> splitWorkers(String codes) {
@@ -115,13 +116,13 @@ public class WorkRecordController {
         return vals;
     }
 
-    private void exportList(java.util.List<WorkRecord> list, HttpServletResponse response) throws IOException {
+    private void exportList(java.util.List<WorkRecord> list, String fileName, HttpServletResponse response) throws IOException {
         Workbook wb = new org.apache.poi.xssf.usermodel.XSSFWorkbook();
         Sheet sheet = wb.createSheet("records");
         CellStyle twoDec = wb.createCellStyle();
         twoDec.setDataFormat(wb.createDataFormat().getFormat("0.00"));
         Row head = sheet.createRow(0);
-        String[] titles = {"通知单号","产品名称","图号","批次号","工序代码","工时","产量","人员代码","姓名","数量分配","工时分配","起始日期","结束日期","合格数","工时小计"};
+        String[] titles = {"日期","通知单号","人员代码","人数","图号","工序代码","数量分配","单件工时","劳资系数","分配调整","单件工时分配","姓名","计划数","产品名称"};
         for (int i = 0; i < titles.length; i++) {
             head.createCell(i).setCellValue(titles[i]);
         }
@@ -132,24 +133,32 @@ public class WorkRecordController {
             java.util.List<String> names = splitNames(r.getWorkerNames());
             java.util.List<Double> qtys = parseQtys(r.getWorkerQtys());
             int max = Math.max(1, Math.max(Math.max(codes.size(), names.size()), qtys.size()));
+            int numWorkers = max;
+
+            String timeCell = "";
+            if (r.getStartTime() != null) {
+                java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("M.d");
+                String s = r.getStartTime().toLocalDate().format(fmt);
+                if (r.getEndTime() != null && !r.getEndTime().toLocalDate().isEqual(r.getStartTime().toLocalDate())) {
+                    String e = r.getEndTime().toLocalDate().format(fmt);
+                    timeCell = s + "-" + e;
+                } else {
+                    timeCell = s;
+                }
+            } else if (r.getEndTime() != null) {
+                java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("M.d");
+                timeCell = r.getEndTime().toLocalDate().format(fmt);
+            }
 
             for (int i = 0; i < max; i++) {
                 Row row = sheet.createRow(rowIdx++);
                 int c = 0;
+                row.createCell(c++).setCellValue(timeCell);
                 row.createCell(c++).setCellValue(n(r.getNotificationNumber()));
-                row.createCell(c++).setCellValue(n(r.getProductName()));
-                row.createCell(c++).setCellValue(n(r.getDrawingNumber()));
-                row.createCell(c++).setCellValue(n(r.getBatchNumber()));
-                row.createCell(c++).setCellValue(n(r.getProcessCode()));
-                if (r.getHours() != null) {
-                    Cell cell = row.createCell(c++);
-                    cell.setCellValue(r.getHours());
-                    cell.setCellStyle(twoDec);
-                } else row.createCell(c++).setCellValue("");
-                if (r.getPlanQty() != null) row.createCell(c++).setCellValue(r.getPlanQty()); else row.createCell(c++).setCellValue("");
                 row.createCell(c++).setCellValue(i < codes.size() ? n(codes.get(i)) : "");
-                row.createCell(c++).setCellValue(i < names.size() ? n(names.get(i)) : "");
-
+                row.createCell(c++).setCellValue(numWorkers);
+                row.createCell(c++).setCellValue(n(r.getDrawingNumber()));
+                row.createCell(c++).setCellValue(n(r.getProcessCode()));
                 Double q = i < qtys.size() ? qtys.get(i) : null;
                 if (q != null) {
                     Cell cell = row.createCell(c++);
@@ -157,7 +166,13 @@ public class WorkRecordController {
                     cell.setCellStyle(twoDec);
                 }
                 else row.createCell(c++).setCellValue("");
-
+                if (r.getHours() != null) {
+                    Cell cell = row.createCell(c++);
+                    cell.setCellValue(r.getHours());
+                    cell.setCellStyle(twoDec);
+                } else row.createCell(c++).setCellValue("");
+                row.createCell(c++).setCellValue("");
+                row.createCell(c++).setCellValue("");
                 Double workerHours = null;
                 if (q != null && r.getHours() != null) workerHours = q * r.getHours();
                 if (workerHours != null) {
@@ -166,32 +181,14 @@ public class WorkRecordController {
                     cell.setCellStyle(twoDec);
                 }
                 else row.createCell(c++).setCellValue("");
-
-                if (i == 0) {
-                    row.createCell(c++).setCellValue(r.getStartTime() == null ? "" : r.getStartTime().toLocalDate().toString());
-                    row.createCell(c++).setCellValue(r.getEndTime() == null ? "" : r.getEndTime().toLocalDate().toString());
-                    if (r.getQualifiedQty() != null) {
-                        Cell cell = row.createCell(c++);
-                        cell.setCellValue(r.getQualifiedQty());
-                        cell.setCellStyle(twoDec);
-                    }
-                    else row.createCell(c++).setCellValue("");
-                    if (r.getHourSubtotal() != null) {
-                        Cell cell = row.createCell(c++);
-                        cell.setCellValue(r.getHourSubtotal());
-                        cell.setCellStyle(twoDec);
-                    }
-                    else row.createCell(c++).setCellValue("");
-                } else {
-                    row.createCell(c++).setCellValue("");
-                    row.createCell(c++).setCellValue("");
-                    row.createCell(c++).setCellValue("");
-                    row.createCell(c++).setCellValue("");
-                }
+                row.createCell(c++).setCellValue(i < names.size() ? n(names.get(i)) : "");
+                if (r.getPlanQty() != null) row.createCell(c++).setCellValue(r.getPlanQty()); else row.createCell(c++).setCellValue("");
+                row.createCell(c++).setCellValue(n(r.getProductName()));
             }
         }
         response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition", "attachment; filename=records.xlsx");
+        String fname = fileName == null || fileName.isEmpty() ? "records.xlsx" : java.net.URLEncoder.encode(fileName, "UTF-8");
+        response.setHeader("Content-Disposition", "attachment; filename=" + fname);
         wb.write(response.getOutputStream());
         wb.close();
     }
@@ -342,7 +339,7 @@ public class WorkRecordController {
                 String notification = getString(row, 42);   // AQ
                 String prodName = getString(row, 5);        // F
                 String drawing = getString(row, 4);         // E
-                Integer qty = getInt(row, 1);               // B -> 产量
+                Integer qty = getInt(row, 1);               // B -> 计划数
 
                 for (int c = 9; c <= 28; c += 2) {          // J..AC pairs
                     String process = getString(row, c);

--- a/backend/src/main/java/com/example/worktime/controller/WorkTimeController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkTimeController.java
@@ -60,7 +60,7 @@ public class WorkTimeController {
                 int idx = 0;
                 while (true) {
                     String pKey = idx == 0 ? "工序" : "工序." + idx;
-                    String hKey = idx == 0 ? "工时" : "工时." + idx;
+                    String hKey = idx == 0 ? "单件工时" : "单件工时." + idx;
                     if (!col.containsKey(pKey) || !col.containsKey(hKey)) break;
                     String process = getString(row, col.get(pKey));
                     Double hours = getDouble(row, col.get(hKey));

--- a/backend/src/main/java/com/example/worktime/controller/WorkerController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkerController.java
@@ -2,6 +2,7 @@ package com.example.worktime.controller;
 
 import com.example.worktime.model.Worker;
 import com.example.worktime.repository.WorkerRepository;
+import com.example.worktime.service.OperationLogService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -13,9 +14,11 @@ import java.util.List;
 @CrossOrigin
 public class WorkerController {
     private final WorkerRepository repository;
+    private final OperationLogService logService;
 
-    public WorkerController(WorkerRepository repository) {
+    public WorkerController(WorkerRepository repository, OperationLogService logService) {
         this.repository = repository;
+        this.logService = logService;
     }
 
     @GetMapping
@@ -40,21 +43,26 @@ public class WorkerController {
     }
 
     @PostMapping
-    public Worker create(@RequestBody Worker worker) {
+    public Worker create(@RequestBody Worker worker, @RequestHeader("X-User") String user) {
         validate(worker);
-        return repository.save(worker);
+        Worker saved = repository.save(worker);
+        logService.log(user, "新增人员 " + worker.getName(), "id=" + saved.getId());
+        return saved;
     }
 
     @PutMapping("/{id}")
-    public Worker update(@PathVariable Long id, @RequestBody Worker worker) {
+    public Worker update(@PathVariable Long id, @RequestBody Worker worker, @RequestHeader("X-User") String user) {
         worker.setId(id);
         validate(worker);
-        return repository.save(worker);
+        Worker saved = repository.save(worker);
+        logService.log(user, "更新人员 " + id, null);
+        return saved;
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
         repository.deleteById(id);
+        logService.log(user, "删除人员 " + id, null);
     }
 
     private void validate(Worker worker) {

--- a/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
+++ b/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
@@ -29,7 +29,8 @@ public class OperationLogFilter extends OncePerRequestFilter {
                 && !request.getRequestURI().startsWith("/api/logs")) {
             OperationLog log = new OperationLog();
             log.setUsername(user);
-            log.setAction(request.getMethod() + " " + request.getRequestURI());
+            String path = request.getRequestURI().replaceFirst("^/api", "");
+            log.setAction(request.getMethod() + " " + path);
             log.setTimestamp(LocalDateTime.now());
             repository.save(log);
         }

--- a/backend/src/main/java/com/example/worktime/model/WorkRecord.java
+++ b/backend/src/main/java/com/example/worktime/model/WorkRecord.java
@@ -32,7 +32,7 @@ public class WorkRecord {
     // 名称
     private String partName;
 
-    // 产量 -> 计划数
+    // 计划数
     private Integer planQty;
 
     // 工序名称
@@ -81,7 +81,7 @@ public class WorkRecord {
     @javax.persistence.Column(precision = 10, scale = 2)
     private Double qualifiedQty;
 
-    // 工时小计 = 合格数量 * 单件工时
+    // 单件工时小计 = 合格数量 * 单件工时
     private Double hourSubtotal;
 
     // 是否已填写合格数

--- a/backend/src/main/java/com/example/worktime/repository/OperationLogRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/OperationLogRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface OperationLogRepository extends JpaRepository<OperationLog, Long> {
     List<OperationLog> findByUsernameOrderByTimestampDesc(String username);
+    List<OperationLog> findAllByOrderByTimestampDesc();
 }

--- a/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
@@ -14,6 +14,8 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
     java.util.List<WorkRecord> findByUploadDate(@org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
                                                 @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
 
+    java.util.List<WorkRecord> findByFilledTrue();
+
     void deleteByFileId(Long fileId);
 
     long countByFileId(Long fileId);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>工时录入</title>
+  <title>单件工时录入</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="/src/assets/style.css" />
 </head>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,7 +4,7 @@
     <div v-else>
       <nav class="navbar navbar-expand navbar-light bg-white">
         <div class="container-fluid">
-          <a class="navbar-brand" href="#">工时录入</a>
+          <a class="navbar-brand" href="#">单件工时录入</a>
           <ul class="navbar-nav">
             <li class="nav-item"><router-link class="nav-link" to="/upload">Excel上传</router-link></li>
             <li class="nav-item"><router-link class="nav-link" to="/records">扫码录入</router-link></li>
@@ -31,6 +31,10 @@ export default {
     return { loggedIn: false }
   },
   created() {
+    window.addEventListener('beforeunload', () => {
+      localStorage.removeItem('loggedIn')
+      localStorage.removeItem('username')
+    })
     this.loggedIn = localStorage.getItem('loggedIn') === 'true'
   },
   methods: {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -3,6 +3,14 @@ body {
   font-family: "Helvetica Neue", Arial, sans-serif;
 }
 
+/* width variables so print layout can be customised */
+:root {
+  --drawing-col-width: 110px;
+  --process-col-width: 220px;
+  --hours-col-width: 70px;
+  --barcode-col-width: 300px;
+}
+
 .section-card {
   background-color: #fff;
   border: 1px solid #dee2e6;
@@ -53,10 +61,24 @@ body {
   border-color: #f0ad4e;
 }
 
+.print-text {
+  display: none;
+}
+
+.print-only {
+  display: none;
+}
+
 /* Only show the preview table when printing */
 @media print {
   body * {
     visibility: hidden;
+  }
+  #preview-table .plan-col {
+    width: 50px !important;  /* 设置计划数列的宽度 */
+  }
+  #preview-table .notification-col {
+    width: 60px !important;  /* 设置通知单号列的宽度 */
   }
   #preview-table, #preview-table * {
     visibility: visible;
@@ -69,5 +91,46 @@ body {
   }
   .no-print {
     display: none !important;
+  }
+  .print-text {
+    display: inline !important;
+  }
+  .print-only {
+     width: 50px;
+    display: table-cell !important;
+  }
+  #preview-table table {
+    table-layout: fixed;
+    font-size: 10px;
+  }
+  #preview-table .process-col {
+    width: var(--process-col-width) !important;
+  }
+  #preview-table .drawing-col {
+    width: var(--drawing-col-width) !important;
+  }
+  #preview-table .hours-col {
+    width: var(--hours-col-width) !important;
+  }
+  #preview-table .hours-col input {
+    width: var(--hours-col-width) !important;
+  }
+  #preview-table th,
+  #preview-table td {
+    white-space: nowrap;
+  }
+  #preview-table tr {
+    page-break-inside: avoid;
+  }
+  #preview-table .barcode-cell {
+    width: var(--barcode-col-width);
+  }
+  #preview-table .barcode-cell img {
+    width: var(--barcode-col-width);
+    height: 80px;
+  }
+  @page {
+    size: A4;
+    margin: 10mm;
   }
 }

--- a/frontend/src/components/OperationLog.vue
+++ b/frontend/src/components/OperationLog.vue
@@ -3,16 +3,20 @@
     <h2 class="h5">操作记录</h2>
     <table class="table table-bordered table-sm table-striped">
       <thead>
-        <tr><th>时间</th><th>操作</th></tr>
+        <tr><th>时间</th><th>操作者</th><th>操作</th></tr>
       </thead>
       <tbody>
         <template v-for="log in logs">
           <tr :key="log.id" @click="log.show = !log.show" style="cursor:pointer">
             <td>{{ log.timestamp.replace('T',' ').slice(0,19) }}</td>
+            <td>{{ log.username }}</td>
             <td class="wrap-text">{{ log.action }}</td>
           </tr>
           <tr v-if="log.show" :key="log.id + '-details'">
-            <td colspan="2" class="pre-wrap">{{ log.details }}</td>
+            <td colspan="3" class="pre-wrap">
+              <div v-if="log.details">{{ log.details }}</div>
+              <div v-for="s in log.sub" :key="s.id">{{ s.action }}</div>
+            </td>
           </tr>
         </template>
       </tbody>
@@ -30,14 +34,25 @@ export default {
   methods: {
     async fetchLogs() {
       const user = localStorage.getItem('username')
-      if (!user) {
-        this.logs = []
-        return
+      const headers = user ? { 'X-User': user } : {}
+      const res = await axios.get('http://localhost:8080/api/logs', { headers })
+      this.logs = this.groupLogs(res.data)
+    },
+    groupLogs(raw) {
+      const grouped = []
+      let current = null
+      for (const log of raw) {
+        log.show = false
+        log.sub = log.sub || []
+        const isApi = /^(GET|POST|PUT|DELETE|PATCH) /.test(log.action) && !log.details
+        if (isApi && current) {
+          current.sub.push(log)
+        } else {
+          grouped.push(log)
+          current = log
+        }
       }
-      const res = await axios.get('http://localhost:8080/api/logs', {
-        headers: { 'X-User': user }
-      })
-      this.logs = res.data
+      return grouped
     }
   }
 }

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -14,6 +14,8 @@
       <button class="btn btn-outline-primary btn-sm" @click="exportFile" :disabled="!records.length">导出</button>
       <input type="date" class="form-control form-control-sm ms-1" style="max-width:160px" v-model="exportDate">
       <button class="btn btn-outline-primary btn-sm ms-1" @click="exportByDate" :disabled="!exportDate">按日期导出</button>
+      <input type="month" class="form-control form-control-sm ms-1" style="max-width:160px" v-model="exportMonth">
+      <button class="btn btn-outline-primary btn-sm ms-1" @click="exportByNaturalMonth" :disabled="!exportMonth">按自然月导出</button>
     </div>
     <div class="mb-2" v-if="records.length">
       计划数:
@@ -152,6 +154,7 @@ export default {
       files: [],
       selectedFileId: '',
       exportDate: '',
+      exportMonth: '',
       viewOnly: false,
       scanBuffer: '',
       planQtyInput: null
@@ -188,6 +191,7 @@ export default {
         if (!Array.isArray(res.data) || !res.data.length) {
           alert('该文件暂无填写记录')
           this.records = []
+          this.planQtyInput = null
         } else {
           await this.processRecords(res.data)
           this.viewOnly = true
@@ -224,14 +228,34 @@ export default {
       a.click()
       window.URL.revokeObjectURL(url)
     },
+    async exportByNaturalMonth() {
+      if (!this.exportMonth) return
+      const [year, month] = this.exportMonth.split('-')
+      const res = await axios.get(
+        `http://localhost:8080/api/workrecords/natural-month/${year}/${month}/export`,
+        { responseType: 'blob' }
+      )
+      const url = window.URL.createObjectURL(new Blob([res.data]))
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `records_${year}-${month}.xlsx`
+      a.click()
+      window.URL.revokeObjectURL(url)
+    },
     async searchByBarcode() {
       const code = this.searchBarcode.trim()
-      if (!code) { this.records = []; return }
+      if (!code) { this.records = []; this.planQtyInput = null; this.viewOnly = false; return }
+      if (this.viewOnly) {
+        this.records = []
+        this.viewOnly = false
+        this.planQtyInput = null
+      }
       const url = `http://localhost:8080/api/workrecords/barcode/${encodeURIComponent(code)}`
       try {
         const res = await axios.get(url)
-        await this.processRecords(res.data)
+        await this.processRecords(res.data, { replace: false })
         this.viewOnly = false
+        this.searchBarcode = ''
       } catch (e) {
         console.error(e)
         alert('查询失败')
@@ -244,6 +268,11 @@ export default {
       }
       this.validateQtyAllocation(rec)
       this.validateHourAllocation(rec)
+      const missing = this.collectMissingFields(rec)
+      if (missing.length) {
+        const proceed = confirm(`以下信息未填写：${missing.join('、')}，是否继续保存？`)
+        if (!proceed) return
+      }
       this.normalizeStart(rec)
       this.normalizeEnd(rec)
       const payload = {
@@ -251,9 +280,9 @@ export default {
         startTime: rec.startDate ? rec.startDate + 'T00:00:00' : null,
         endTime: rec.endDate ? rec.endDate + 'T00:00:00' : null
       }
-      await axios.put(`http://localhost:8080/api/workrecords/${rec.id}`, payload)
+      const res = await axios.put(`http://localhost:8080/api/workrecords/${rec.id}`, payload)
       rec.editing = false
-      this.searchByBarcode()
+      await this.processRecords([res.data], { replace: false })
     },
     async addRecord() {
       if (this.records.some(r => r.editing)) {
@@ -262,30 +291,8 @@ export default {
       }
       if (!this.records.length) return
       const id = this.records[0].id
-        const res = await axios.post(`http://localhost:8080/api/workrecords/duplicate/${id}`)
-        const rec = {
-          ...res.data,
-          editing: false,
-          workshop: '',
-          team: '',
-          workerQtys: '',
-          workerHours: '',
-          workerQtyVals: [],
-          workerHourVals: [],
-          workerNamesList: [],
-          codeToName: {},
-          startDate: '',
-          endDate: '',
-          _hourOverflowShown: false
-        }
-      if (rec.qualifiedQty != null && rec.hours != null) {
-        rec.hourSubtotal = rec.qualifiedQty * rec.hours
-      }
-      if (rec.workerCodes) await this.lookupWorker(rec)
-      this.computeWorkerHours(rec)
-      this.records.push(rec)
-      // reload from backend to ensure state consistent
-      this.searchByBarcode()
+      const res = await axios.post(`http://localhost:8080/api/workrecords/duplicate/${id}`)
+      await this.processRecords([res.data], { replace: false })
     },
     async deleteRecord(rec) {
       if (!confirm('确定删除这条记录?')) return
@@ -293,36 +300,58 @@ export default {
         await axios.delete(`http://localhost:8080/api/workrecords/${rec.id}`)
         const idx = this.records.indexOf(rec)
         if (idx !== -1) this.records.splice(idx, 1)
-        // ensure UI reflects backend state
-        this.searchByBarcode()
+        if (!this.records.length) this.planQtyInput = null
       } catch (e) {
         console.error(e)
         alert('删除失败')
       }
     },
-    async processRecords(list) {
-      this.records = list.map(r => ({
-        ...r,
+    async processRecords(list, options = {}) {
+      const replace = options.replace === undefined ? true : options.replace
+      const prepared = []
+      for (const raw of list) {
+        const rec = this.decorateRecord(raw)
+        this.computeSubtotal(rec)
+        if (rec.workerCodes) await this.lookupWorker(rec)
+        this.computeWorkerHours(rec)
+        prepared.push(rec)
+      }
+      if (replace) {
+        this.records = prepared
+        this.planQtyInput = this.planQty
+      } else {
+        const existingMap = new Map(this.records.map(r => [r.id, r]))
+        for (const rec of prepared) {
+          const existing = existingMap.get(rec.id)
+          if (existing) {
+            const wasEditing = existing.editing
+            Object.assign(existing, rec)
+            existing.editing = wasEditing
+          } else {
+            this.records.push(rec)
+          }
+        }
+        if (this.planQtyInput == null && this.planQty != null) {
+          this.planQtyInput = this.planQty
+        }
+      }
+    },
+    decorateRecord(raw) {
+      return {
+        ...raw,
         editing: false,
         workshop: '',
         team: '',
-        workerQtys: r.workerQtys || '',
-        workerHours: '',
-        workerQtyVals: this.parseAllocValues(r.workerQtys),
+        workerQtys: raw.workerQtys || '',
+        workerHours: raw.workerHours || '',
+        workerQtyVals: this.parseAllocValues(raw.workerQtys),
         workerHourVals: [],
         workerNamesList: [],
         codeToName: {},
-        startDate: r.startTime ? r.startTime.slice(0,10) : '',
-        endDate: r.endTime ? r.endTime.slice(0,10) : '',
+        startDate: raw.startTime ? raw.startTime.slice(0, 10) : '',
+        endDate: raw.endTime ? raw.endTime.slice(0, 10) : '',
+        hourSubtotal: raw.hourSubtotal != null ? raw.hourSubtotal : (raw.qualifiedQty != null && raw.hours != null ? raw.qualifiedQty * raw.hours : null),
         _hourOverflowShown: false
-      }))
-      this.planQtyInput = this.planQty
-      for (const rec of this.records) {
-        if (rec.qualifiedQty != null && rec.hours != null) {
-          rec.hourSubtotal = rec.qualifiedQty * rec.hours
-        }
-        if (rec.workerCodes) await this.lookupWorker(rec)
-        this.computeWorkerHours(rec)
       }
     },
     computeSubtotal(row) {
@@ -504,11 +533,10 @@ export default {
       const t = e.target.tagName
       if (t === 'INPUT' || t === 'TEXTAREA') return
       if (e.key === 'Enter') {
-        if (this.scanBuffer) {
-          this.searchBarcode = this.scanBuffer
-          this.scanBuffer = ''
-          this.searchByBarcode()
-        }
+        if (!this.scanBuffer) return
+        this.searchBarcode = this.scanBuffer
+        this.scanBuffer = ''
+        this.searchByBarcode()
       } else if (e.key.length === 1) {
         this.scanBuffer += e.key
       }
@@ -534,6 +562,15 @@ export default {
     normalizeEnd(rec) {
       rec.endDate = this.normalizeDate(rec.endDate)
       if (!rec.endDate) rec.endDate = rec.startDate
+    },
+    collectMissingFields(rec) {
+      const missing = []
+      if (rec.planQty == null || rec.planQty === '') missing.push('计划数')
+      if (!rec.workerCodes || !rec.workerCodes.trim()) missing.push('人员代码')
+      if (rec.qualifiedQty == null || rec.qualifiedQty === '') missing.push('合格数')
+      if (!rec.startDate || !rec.startDate.toString().trim()) missing.push('起始日期')
+      if (!rec.endDate || !rec.endDate.toString().trim()) missing.push('结束日期')
+      return missing
     }
   }
 }

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -2,7 +2,7 @@
   <section class="section-card">
     <h2 class="h5">扫码录入</h2>
     <div class="input-group mb-2" style="max-width:300px;">
-      <input class="form-control form-control-sm" v-model="searchBarcode" placeholder="扫码条形码" />
+      <input class="form-control form-control-sm" v-model="searchBarcode" placeholder="扫码条形码" @keyup.enter="searchByBarcode" />
       <button class="btn btn-outline-secondary btn-sm" @click="searchByBarcode">查询</button>
     </div>
     <div class="input-group mb-2" style="max-width:400px;">
@@ -16,7 +16,9 @@
       <button class="btn btn-outline-primary btn-sm ms-1" @click="exportByDate" :disabled="!exportDate">按日期导出</button>
     </div>
     <div class="mb-2" v-if="records.length">
-      产量: {{ planQty }} | 总合格数: {{ totalQualified }} | 已填写 {{ records.length }} 条
+      计划数:
+      <input type="number" class="form-control form-control-sm d-inline-block" style="width:80px" v-model.number="planQtyInput" @change="updatePlanQty" />
+      | 总合格数: {{ totalQualified }} | 已填写 {{ records.length }} 条
       <button v-if="!viewOnly" class="btn btn-sm btn-outline-secondary ms-2" @click="addRecord">新增记录</button>
     </div>
     <table class="table table-bordered table-sm table-striped">
@@ -26,10 +28,9 @@
           <th>通知单号</th>
           <th>产品名称</th>
           <th>图号</th>
-          <th>批次号</th>
           <th>工序代码</th>
-          <th>工时</th>
-          <th>产量</th>
+          <th>单件工时</th>
+          <th>计划数</th>
           <th>人员代码</th>
           <th>数量分配</th>
           <th>姓名</th>
@@ -38,8 +39,8 @@
           <th>起始日期</th>
           <th>结束日期</th>
           <th>合格数</th>
-          <th>工时小计</th>
-          <th>工时分配</th>
+          <th>单件工时小计</th>
+          <th>单件工时分配</th>
           <th v-if="!viewOnly"></th>
         </tr>
       </thead>
@@ -49,13 +50,19 @@
           <td class="wrap-text">{{ rec.notificationNumber }}</td>
           <td class="wrap-text">{{ rec.productName }}</td>
           <td class="wrap-text">{{ rec.drawingNumber }}</td>
-          <td>
-            <span v-if="!rec.editing">{{ rec.batchNumber }}</span>
-            <input v-else class="form-control form-control-sm edit-highlight" v-model="rec.batchNumber" style="width:80px" />
-          </td>
           <td>{{ rec.processCode }}</td>
           <td>{{ rec.hours }}</td>
-          <td>{{ rec.planQty }}</td>
+          <td>
+            <span v-if="!rec.editing">{{ rec.planQty }}</span>
+            <input
+              v-else
+              type="number"
+              class="form-control form-control-sm edit-highlight"
+              style="width:80px"
+              v-model.number="rec.planQty"
+              @blur="onPlanQtyCellChange(rec)"
+            />
+          </td>
           <td class="wrap-text">
             <span v-if="!rec.editing">{{ rec.workerCodes }}</span>
             <textarea
@@ -92,11 +99,11 @@
           <td class="wrap-text">{{ rec.team }}</td>
           <td>
             <span v-if="!rec.editing">{{ rec.startDate }}</span>
-            <input v-else type="date" class="form-control form-control-sm edit-highlight" v-model="rec.startDate" style="width:130px" />
+            <input v-else type="text" class="form-control form-control-sm edit-highlight" v-model="rec.startDate" @blur="normalizeStart(rec)" style="width:130px" placeholder="MM/DD" />
           </td>
           <td>
             <span v-if="!rec.editing">{{ rec.endDate }}</span>
-            <input v-else type="date" class="form-control form-control-sm edit-highlight" v-model="rec.endDate" style="width:130px" />
+            <input v-else type="text" class="form-control form-control-sm edit-highlight" v-model="rec.endDate" @blur="normalizeEnd(rec)" style="width:130px" placeholder="MM/DD" />
           </td>
           <td>
             <span v-if="!rec.editing">{{ rec.qualifiedQty }}</span>
@@ -145,11 +152,19 @@ export default {
       files: [],
       selectedFileId: '',
       exportDate: '',
-      viewOnly: false
+      viewOnly: false,
+      scanBuffer: '',
+      planQtyInput: null
     }
   },
   created() {
     this.fetchFiles()
+  },
+  mounted() {
+    window.addEventListener('keydown', this.handleScanKey)
+  },
+  beforeUnmount() {
+    window.removeEventListener('keydown', this.handleScanKey)
   },
   computed: {
     planQty() {
@@ -191,7 +206,8 @@ export default {
       const url = window.URL.createObjectURL(new Blob([res.data]))
       const a = document.createElement('a')
       a.href = url
-      a.download = 'records.xlsx'
+      const f = this.files.find(x => x.id === this.selectedFileId)
+      a.download = f ? f.fileName : 'records.xlsx'
       a.click()
       window.URL.revokeObjectURL(url)
     },
@@ -224,10 +240,12 @@ export default {
     async updateRecord(rec) {
       const total = this.records.reduce((sum, r) => sum + (r === rec ? (rec.qualifiedQty || 0) : (r.qualifiedQty || 0)), 0)
       if (this.planQty != null && total > this.planQty) {
-        alert('总合格数已超过产量，请确认')
+        alert('总合格数已超过计划数，请确认')
       }
       this.validateQtyAllocation(rec)
       this.validateHourAllocation(rec)
+      this.normalizeStart(rec)
+      this.normalizeEnd(rec)
       const payload = {
         ...rec,
         startTime: rec.startDate ? rec.startDate + 'T00:00:00' : null,
@@ -257,7 +275,8 @@ export default {
           workerNamesList: [],
           codeToName: {},
           startDate: '',
-          endDate: ''
+          endDate: '',
+          _hourOverflowShown: false
         }
       if (rec.qualifiedQty != null && rec.hours != null) {
         rec.hourSubtotal = rec.qualifiedQty * rec.hours
@@ -294,8 +313,10 @@ export default {
         workerNamesList: [],
         codeToName: {},
         startDate: r.startTime ? r.startTime.slice(0,10) : '',
-        endDate: r.endTime ? r.endTime.slice(0,10) : ''
+        endDate: r.endTime ? r.endTime.slice(0,10) : '',
+        _hourOverflowShown: false
       }))
+      this.planQtyInput = this.planQty
       for (const rec of this.records) {
         if (rec.qualifiedQty != null && rec.hours != null) {
           rec.hourSubtotal = rec.qualifiedQty * rec.hours
@@ -333,7 +354,7 @@ export default {
     validatePlanQty() {
       const total = this.records.reduce((sum, r) => sum + (r.qualifiedQty || 0), 0)
       if (this.planQty != null && total > this.planQty) {
-        alert('总合格数已超过产量，请确认')
+        alert('总合格数已超过计划数，请确认')
       }
     },
     validateQtyAllocation(rec) {
@@ -348,8 +369,19 @@ export default {
       const sum = rec.workerHourVals.reduce((a,b) => a + (parseFloat(b) || 0), 0)
       const total = (rec.qualifiedQty || 0) * (rec.hours || 0)
       if (total && sum > total) {
-        alert('填写的工时超过总工时')
+        if (!rec._hourOverflowShown) alert('填写的单件工时超过总工时')
+        rec._hourOverflowShown = true
+      } else {
+        rec._hourOverflowShown = false
       }
+    },
+    onPlanQtyCellChange(rec) {
+      this.planQtyInput = rec.planQty
+      this.updatePlanQty()
+    },
+    updatePlanQty() {
+      this.records.forEach(r => { r.planQty = this.planQtyInput })
+      this.validatePlanQty()
     },
     async lookupWorker(rec) {
       const codes = rec.workerCodes ? rec.workerCodes.split(/[,\u3001\s]+/) : []
@@ -467,6 +499,41 @@ export default {
       if (!el) return
       el.style.height = 'auto'
       el.style.height = el.scrollHeight + 'px'
+    },
+    handleScanKey(e) {
+      const t = e.target.tagName
+      if (t === 'INPUT' || t === 'TEXTAREA') return
+      if (e.key === 'Enter') {
+        if (this.scanBuffer) {
+          this.searchBarcode = this.scanBuffer
+          this.scanBuffer = ''
+          this.searchByBarcode()
+        }
+      } else if (e.key.length === 1) {
+        this.scanBuffer += e.key
+      }
+    },
+    normalizeDate(str) {
+      if (!str) return ''
+      str = str.trim()
+      if (/^\d{1,2}\/\d{1,2}$/.test(str)) {
+        const [m, d] = str.split('/')
+        const y = new Date().getFullYear()
+        return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`
+      }
+      if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(str)) {
+        const [y,m,d] = str.split('-')
+        return `${y}-${m.padStart(2,'0')}-${d.padStart(2,'0')}`
+      }
+      return str
+    },
+    normalizeStart(rec) {
+      rec.startDate = this.normalizeDate(rec.startDate)
+      if (!rec.endDate) rec.endDate = rec.startDate
+    },
+    normalizeEnd(rec) {
+      rec.endDate = this.normalizeDate(rec.endDate)
+      if (!rec.endDate) rec.endDate = rec.startDate
     }
   }
 }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -20,33 +20,57 @@
       <table class="table table-bordered table-sm table-striped">
         <thead>
           <tr>
-            <th>通知单号</th>
-            <th>产品名称</th>
-            <th>图号</th>
-            <th>名称</th>
-            <th>计划数</th>
-            <th>工序代码</th>
-            <th>工序</th>
-            <th>工时</th>
+            <th class="notification-col">通知单号</th>
+            <th class="no-print">产品名称</th>
+            <th class="drawing-col">图号</th>
+            <th class="print-only plan-col">计划数</th>
+            <th class="no-print">名称</th>
+            <th class="plan-col no-print">计划数</th>
+            <th class="hours-col">单件工时</th>
+            <th class="no-print">工序代码</th>
+            <th class="process-col">工序</th>
+            <th class="print-only">人员代码</th>
+            <th class="print-only">合格件数</th>
+            <th class="print-only">起始时间</th>
+            <th class="print-only">结束时间</th>
+            <th class="print-only">检验员</th>
             <th>条形码</th>
             <th class="no-print"></th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="(r,i) in preview" :key="i" :class="{'table-danger': r.codeMissing || r.hoursMissing}">
-            <td>{{ r.notificationNumber }}</td>
-            <td>{{ r.productName }}</td>
-            <td>{{ r.drawingNumber }}</td>
-            <td>{{ r.partName }}</td>
-            <td>{{ r.planQty }}</td>
-            <td>{{ r.processCode }}</td>
-            <td><input class="form-control form-control-sm" v-model="r.processName" @blur="updateProcess(r)"/></td>
-            <td><input type="number" class="form-control form-control-sm" v-model.number="r.hours" @blur="checkHours(r)" style="width:80px"/></td>
+            <td class="notification-col">{{ r.notificationNumber }}</td>
+            <td class="no-print">{{ r.productName }}</td>
+            <td class="drawing-col">{{ r.drawingNumber }}</td>
+            <td class="print-only plan-col">{{ r.planQty }}</td>
+            <td class="no-print">{{ r.partName }}</td>
+            <td class="plan-col no-print">
+              <input type="number" class="form-control form-control-sm" v-model.number="r.planQty" />
+              <span class="print-text">{{ r.planQty }}</span>
+            </td>
+            <td class="hours-col">
+              <input type="number" class="form-control form-control-sm no-print" v-model.number="r.hours" @blur="checkHours(r)" style="width:80px" />
+              <span class="print-text">{{ r.hours }}</span>
+            </td>
+            <td class="no-print">{{ r.processCode }}</td>
+            <td class="process-col">
+              <input class="form-control form-control-sm no-print" v-model="r.processName" @blur="updateProcess(r)" />
+              <span class="print-text">{{ r.processName }}</span>
+            </td>
+            <td class="print-only"></td>
+            <td class="print-only"></td>
+            <td class="print-only"></td>
+            <td class="print-only"></td>
+            <td class="print-only"></td>
             <td class="barcode-cell">
               <div>{{ r.barcode }}</div>
               <img v-if="r.barcodeImage" :src="'data:image/png;base64,'+r.barcodeImage" />
             </td>
-            <td class="no-print"><button class="btn btn-sm btn-outline-danger" @click="deleteRow(i)">删除</button></td>
+            <td class="no-print">
+              <button class="btn btn-sm btn-outline-primary me-1" @click="addRow(i)">新增</button>
+              <button class="btn btn-sm btn-outline-danger" @click="deleteRow(i)">删除</button>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -69,6 +93,14 @@ export default {
   },
   created() {
     this.fetchFiles()
+  },
+  computed: {
+    currentFileName() {
+      if (this.file) return this.file.name
+      const id = this.fileId || this.selectedFileId
+      const f = this.files.find(x => x.id === id)
+      return f ? f.fileName : ''
+    }
   },
   methods: {
     onFileChange(e) { this.file = e.target.files[0] },
@@ -128,7 +160,7 @@ export default {
       this.fileId = res.data.fileId
       this.preview = res.data.records.map(r => ({ ...r, workerCodes:'', qualifiedQty:null, hourSubtotal:null }))
       const warn = this.preview.filter(r => r.codeMissing || r.hoursMissing)
-      if (warn.length) alert(`发现${warn.length}条记录缺少工时或工序码，请检查`)
+      if (warn.length) alert(`发现${warn.length}条记录缺少单件工时或工序码，请检查`)
       await this.fetchFiles()
       this.loading = false
     },
@@ -150,20 +182,10 @@ export default {
       this.$emit('saved')
     },
     print() {
-      if (!this.fileId) {
-        alert('请先保存文件后再打印')
-        return
-      }
-      axios.get(`http://localhost:8080/api/workrecords/file/${this.fileId}/print`, { responseType: 'blob' })
-        .then(res => {
-          const url = window.URL.createObjectURL(new Blob([res.data]))
-          const a = document.createElement('a')
-          a.href = url
-          a.download = 'print.xlsx'
-          a.click()
-          window.URL.revokeObjectURL(url)
-        })
-        .catch(() => alert('打印文件生成失败'))
+      const title = document.title
+      if (this.currentFileName) document.title = this.currentFileName
+      window.print()
+      document.title = title
     },
     sanitize(text) {
       return text ? text.replace(/[^\x00-\x7F]/g, '') : ''
@@ -197,6 +219,29 @@ export default {
       if (confirm('确定删除该行? 删除后不可恢复')) {
         this.preview.splice(index, 1)
       }
+    },
+    addRow(index) {
+      const base = this.preview[index]
+      const blank = {
+        notificationNumber: base.notificationNumber,
+        productName: base.productName,
+        drawingNumber: base.drawingNumber,
+        partName: base.partName,
+        planQty: null,
+        processCode: '',
+        processName: '',
+        hours: null,
+        workerCodes: '',
+        qualifiedQty: null,
+        startTime: '',
+        endTime: '',
+        inspector: '',
+        barcode: '',
+        barcodeImage: '',
+        codeMissing: true,
+        hoursMissing: true
+      }
+      this.preview.splice(index + 1, 0, blank)
     },
     deleteZero() {
       if (!this.preview.length) return


### PR DESCRIPTION
## Summary
- rename "工时" fields to "单件工时" and replace "产量" with "计划数"
- merge start/end into a single "起始时间" column when exporting
- allow updating the plan quantity on the scanning page
- place start time column after process code in exported spreadsheets
- make plan quantity editable per row in the scanner
- move "单件工时" next to "计划数" in the upload preview table
- show plan quantity after drawing number in print view
- reorder export columns and include person count with blank labor fields

## Testing
- `npm install --prefix frontend`
- `npm run --prefix frontend build`
- `mvn -q -f backend/pom.xml -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688810096f08832cbc3aee82c1234607