### PR TITLE
Fix FormData upload header

### DIFF
--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -256,7 +256,7 @@ export default {
       this.loading = true; this.showProgress = true; this.parseProgress = 5; this.barcodeCache = {}
       try {
         const data = new FormData(); data.append('file', this.file)
-        const res = await axios.post('/api/api/workrecords/parse', data, { headers: { 'Content-Type': 'multipart/form-data' } })
+        const res = await axios.post('/api/api/workrecords/parse', data)
         this.fileId = res.data.fileId
         const records = Array.isArray(res.data.records) ? res.data.records : []
         const processed = []; const total = records.length


### PR DESCRIPTION
## Summary
- remove the manual multipart/form-data header from the RecordUpload parse request so the browser can include the boundary automatically

## Testing
- npm run --prefix frontend build
- node <<'NODE' ... (POST FormData to stub backend and verified the file part was received)


------
https://chatgpt.com/codex/tasks/task_e_68cdee4bb9b8832c87090463f634f4bb