### PR TITLE
Fix Excel upload preview and improve barcode handling

### DIFF
--- a/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
+++ b/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
@@ -3,11 +3,13 @@ package com.example.worktime.controller;
 import com.example.worktime.model.ProcessCode;
 import com.example.worktime.repository.ProcessCodeRepository;
 import com.example.worktime.service.OperationLogService;
+import com.example.worktime.service.ProcessCodeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/processcodes")
@@ -15,10 +17,14 @@ import java.util.List;
 public class ProcessCodeController {
     private final ProcessCodeRepository repository;
     private final OperationLogService logService;
+    private final ProcessCodeService processService;
 
-    public ProcessCodeController(ProcessCodeRepository repository, OperationLogService logService) {
+    public ProcessCodeController(ProcessCodeRepository repository,
+                                 OperationLogService logService,
+                                 ProcessCodeService processService) {
         this.repository = repository;
         this.logService = logService;
+        this.processService = processService;
     }
 
     @GetMapping
@@ -38,6 +44,11 @@ public class ProcessCodeController {
     @GetMapping("/name/{name}")
     public ProcessCode byName(@PathVariable String name) {
         return repository.findByName(name);
+    }
+
+    @PostMapping("/lookup")
+    public Map<String, String> lookup(@RequestBody List<String> names) {
+        return processService.getCodes(names);
     }
 
     @PostMapping

--- a/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
+++ b/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
@@ -51,6 +51,26 @@ public class ProcessCodeController {
         return processService.getCodes(names);
     }
 
+    @PostMapping("/remember")
+    public ProcessCode remember(@RequestBody Map<String, String> payload, @RequestHeader("X-User") String user) {
+        String name = payload != null ? payload.get("name") : null;
+        String code = payload != null ? payload.get("code") : null;
+        if (name == null || name.trim().isEmpty() || code == null || code.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序名称和工序代号均不能为空");
+        }
+        ProcessCode existing = repository.findByName(name.trim());
+        ProcessCode saved = processService.rememberMapping(name, code);
+        if (saved == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序名称和工序代号均不能为空");
+        }
+        if (existing == null) {
+            logService.log(user, "新增工序 " + saved.getName(), "id=" + saved.getId());
+        } else {
+            logService.log(user, "更新工序 " + existing.getId(), null);
+        }
+        return saved;
+    }
+
     @PostMapping
     public ProcessCode create(@RequestBody ProcessCode pc, @RequestHeader("X-User") String user) {
         validate(pc);

--- a/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
+++ b/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
@@ -58,8 +58,11 @@ public class ProcessCodeController {
         if (name == null || name.trim().isEmpty() || code == null || code.trim().isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序名称和工序代号均不能为空");
         }
-        ProcessCode existing = repository.findByName(name.trim());
-        ProcessCode saved = processService.rememberMapping(name, code);
+        String trimmedName = name.trim();
+        String trimmedCode = code.trim();
+        ProcessCode existing = repository.findByName(trimmedName);
+        ensureUniqueCode(trimmedCode, existing != null ? existing.getId() : null);
+        ProcessCode saved = processService.rememberMapping(trimmedName, trimmedCode);
         if (saved == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序名称和工序代号均不能为空");
         }
@@ -95,11 +98,27 @@ public class ProcessCodeController {
     }
 
     private void validate(ProcessCode pc) {
-        if (pc.getCode() == null || pc.getCode().trim().isEmpty()) {
+        String code = pc.getCode() != null ? pc.getCode().trim() : null;
+        if (code == null || code.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序代号不能为空");
         }
-        if (pc.getName() == null || pc.getName().trim().isEmpty()) {
+        String name = pc.getName() != null ? pc.getName().trim() : null;
+        if (name == null || name.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序名称不能为空");
+        }
+        pc.setCode(code);
+        pc.setName(name);
+        ensureUniqueCode(code, pc.getId());
+    }
+
+    private void ensureUniqueCode(String code, Long currentId) {
+        if (code == null || code.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序代号不能为空");
+        }
+        String trimmed = code.trim();
+        ProcessCode duplicate = repository.findByCode(trimmed);
+        if (duplicate != null && (currentId == null || !duplicate.getId().equals(currentId))) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "工序代号已存在，请使用其他代号");
         }
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -702,8 +703,24 @@ public class WorkRecordController {
     }
 
     private String sanitizeBarcode(String text) {
-        if (text == null) return null;
-        return text.replaceAll("[^\\x00-\\x7F]", "").replaceAll("\\s+", "");
+        if (text == null) {
+            return null;
+        }
+        String normalized = Normalizer.normalize(text, Normalizer.Form.NFKC);
+        StringBuilder builder = new StringBuilder();
+        normalized.codePoints().forEach(cp -> {
+            if (Character.isWhitespace(cp)) {
+                return;
+            }
+            int type = Character.getType(cp);
+            if (type == Character.CONTROL || type == Character.FORMAT
+                    || type == Character.PRIVATE_USE || type == Character.SURROGATE
+                    || type == Character.UNASSIGNED) {
+                return;
+            }
+            builder.appendCodePoint(cp);
+        });
+        return builder.toString();
     }
 
     private String n(String v) { return v == null ? "" : v; }

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -400,6 +400,74 @@ public class WorkRecordController {
         return result;
     }
 
+    @PostMapping("/autosave")
+    @Transactional
+    public WorkRecord autoSave(@RequestParam("fileId") Long fileId,
+                               @RequestBody WorkRecord record,
+                               @RequestHeader("X-User") String user) {
+        if (fileId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "fileId 不能为空");
+        }
+        if (record == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "记录不能为空");
+        }
+        UploadedFile file = fileRepository.findById(fileId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "无效文件"));
+        WorkRecord existing = null;
+        if (record.getId() != null) {
+            existing = repository.findById(record.getId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "record not found: " + record.getId()));
+            record.setId(existing.getId());
+            record.setFile(existing.getFile());
+            if (record.getBarcode() == null) {
+                record.setBarcode(existing.getBarcode());
+            }
+            if (record.getBarcodeImage() == null) {
+                record.setBarcodeImage(existing.getBarcodeImage());
+            }
+            if (record.getSupplemental() == null) {
+                record.setSupplemental(existing.getSupplemental());
+            }
+            if (record.getFilled() == null) {
+                record.setFilled(existing.getFilled());
+            }
+            if (existing.getFile() != null && existing.getFile().getId() != null
+                    && !existing.getFile().getId().equals(fileId)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "记录不属于指定文件");
+            }
+        } else {
+            record.setFile(file);
+            if (record.getFilled() == null) {
+                record.setFilled(Boolean.FALSE);
+            }
+        }
+        String barcode = sanitizeBarcode(record.getBarcode());
+        record.setBarcode(barcode);
+        prepare(record, false);
+        YearMonth ym = determineNaturalMonth(record);
+        record.setNaturalMonth(ym != null ? ym.toString() : null);
+        if (record.getQualifiedQty() != null) {
+            record.setFilled(true);
+        }
+        if (barcode != null && !barcode.trim().isEmpty()) {
+            String trimmed = barcode.trim();
+            String existingBarcode = existing != null ? sanitizeBarcode(existing.getBarcode()) : null;
+            if (record.getId() == null || existingBarcode == null || !existingBarcode.equals(trimmed)) {
+                boolean supplemental = fetchExistingBarcodes(Collections.singleton(trimmed)).contains(trimmed);
+                record.setSupplemental(supplemental);
+            } else if (record.getSupplemental() == null && existing != null) {
+                record.setSupplemental(existing.getSupplemental());
+            }
+        } else {
+            record.setSupplemental(Boolean.FALSE);
+        }
+        WorkRecord saved = repository.save(record);
+        repository.flush();
+        logService.log(user, "自动保存记录", "id=" + saved.getId());
+        flagIssues(saved);
+        return saved;
+    }
+
     @PutMapping("/{id}")
     @Transactional
     public WorkRecord update(@PathVariable Long id, @RequestBody WorkRecord record,

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -172,7 +172,7 @@ public class WorkRecordController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "图号不能为空");
         }
         String normalized = drawing.trim();
-        List<WorkRecord> list = repository.findByDrawingNumber(normalized);
+        List<WorkRecord> list = repository.findByDrawingNumberAndFilledTrue(normalized);
         String sanitized = normalized.replaceAll("[\\\\/:*?\"<>|]", "_");
         if (sanitized.isEmpty()) {
             sanitized = "records";
@@ -243,8 +243,8 @@ public class WorkRecordController {
             java.util.List<String> codes = splitWorkers(r.getWorkerCodes());
             java.util.List<String> names = splitNames(r.getWorkerNames());
             java.util.List<Double> qtys = parseQtys(r.getWorkerQtys());
-            int max = Math.max(1, Math.max(Math.max(codes.size(), names.size()), qtys.size()));
-            int numWorkers = max;
+            int assignmentCount = Math.max(Math.max(codes.size(), names.size()), qtys.size());
+            int max = Math.max(1, assignmentCount);
 
             String timeCell = "";
             if (r.getStartTime() != null) {
@@ -267,7 +267,12 @@ public class WorkRecordController {
                 row.createCell(c++).setCellValue(timeCell);
                 row.createCell(c++).setCellValue(n(r.getNotificationNumber()));
                 row.createCell(c++).setCellValue(i < codes.size() ? n(codes.get(i)) : "");
-                row.createCell(c++).setCellValue(numWorkers);
+                Cell workerCountCell = row.createCell(c++);
+                if (assignmentCount > 0) {
+                    workerCountCell.setCellValue(assignmentCount > 1 ? 1 : assignmentCount);
+                } else {
+                    workerCountCell.setCellValue("");
+                }
                 row.createCell(c++).setCellValue(n(r.getDrawingNumber()));
                 row.createCell(c++).setCellValue(n(r.getProcessCode()));
                 Double q = i < qtys.size() ? qtys.get(i) : null;

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -140,12 +140,15 @@ public class WorkRecordController {
         } catch (DateTimeException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "无效的月份");
         }
-        List<WorkRecord> filled = repository.findByFilledTrue();
-        List<WorkRecord> filtered = new ArrayList<>();
-        for (WorkRecord record : filled) {
-            YearMonth recordMonth = determineNaturalMonth(record);
-            if (ym.equals(recordMonth)) {
-                filtered.add(record);
+        String monthKey = ym.toString();
+        List<WorkRecord> filtered = new ArrayList<>(repository.findByNaturalMonthAndFilledTrue(monthKey));
+        if (filtered.isEmpty()) {
+            List<WorkRecord> filled = repository.findByFilledTrue();
+            for (WorkRecord record : filled) {
+                YearMonth recordMonth = determineNaturalMonth(record);
+                if (ym.equals(recordMonth)) {
+                    filtered.add(record);
+                }
             }
         }
         String fileName = String.format("records_%s.xlsx", ym);
@@ -446,17 +449,30 @@ public class WorkRecordController {
                                  @RequestHeader("X-User") String user) {
         UploadedFile file = fileRepository.findById(fileId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "无效文件"));
+        java.util.Set<String> candidates = new java.util.LinkedHashSet<>();
         for (WorkRecord r : records) {
             r.setFile(file);
             r.setFilled(false);
+            String barcode = sanitizeBarcode(r.getBarcode());
+            r.setBarcode(barcode);
             prepare(r);
             YearMonth ym = determineNaturalMonth(r);
             r.setNaturalMonth(ym != null ? ym.toString() : null);
-            r.setSupplemental(!repository.findByBarcode(r.getBarcode()).isEmpty());
+            if (barcode != null && !barcode.trim().isEmpty()) {
+                candidates.add(barcode);
+            }
+        }
+        java.util.Set<String> existing = fetchExistingBarcodes(candidates);
+        for (WorkRecord r : records) {
+            String barcode = r.getBarcode();
+            if (barcode != null && !barcode.trim().isEmpty()) {
+                r.setSupplemental(existing.contains(barcode));
+            } else {
+                r.setSupplemental(Boolean.FALSE);
+            }
         }
         java.util.List<WorkRecord> saved = repository.saveAll(records);
         repository.flush();
-        System.out.println("Saved records: " + saved.size());
         logService.log(user, "新增记录" , "fileId=" + fileId + " count=" + saved.size());
         return saved;
     }
@@ -467,12 +483,6 @@ public class WorkRecordController {
                                      @RequestParam(value = "password", required = false) String password,
                                      @RequestParam(value = "store", required = false, defaultValue = "true") boolean store,
                                      @RequestHeader("X-User") String user) throws IOException {
-        UploadedFile uf = new UploadedFile();
-        uf.setFileName(file.getOriginalFilename());
-        uf.setData(file.getBytes());
-        uf.setUploadTime(java.time.LocalDateTime.now());
-        uf = fileRepository.saveAndFlush(uf);
-
         List<WorkRecord> parsed = parseExcel(file, password);
         int codeMissing = 0;
         int hoursMissing = 0;
@@ -480,6 +490,14 @@ public class WorkRecordController {
             if (Boolean.TRUE.equals(wr.getCodeMissing())) codeMissing++;
             if (Boolean.TRUE.equals(wr.getHoursMissing())) hoursMissing++;
         }
+
+        UploadedFile uf = new UploadedFile();
+        uf.setFileName(file.getOriginalFilename());
+        uf.setUploadTime(java.time.LocalDateTime.now());
+        if (store) {
+            uf.setData(file.getBytes());
+        }
+        uf = fileRepository.saveAndFlush(uf);
 
         if (store && !parsed.isEmpty()) {
             final int batchSize = 500;
@@ -491,9 +509,12 @@ public class WorkRecordController {
                     prepare(wr, false);
                     YearMonth ym = determineNaturalMonth(wr);
                     wr.setNaturalMonth(ym != null ? ym.toString() : null);
+                }
+                java.util.Set<String> existing = fetchExistingBarcodesFromChunk(chunk);
+                for (WorkRecord wr : chunk) {
                     String barcode = wr.getBarcode();
                     if (barcode != null && !barcode.trim().isEmpty()) {
-                        wr.setSupplemental(!repository.findByBarcode(barcode).isEmpty());
+                        wr.setSupplemental(existing.contains(barcode));
                     } else {
                         wr.setSupplemental(Boolean.FALSE);
                     }
@@ -514,9 +535,59 @@ public class WorkRecordController {
         if (!store) {
             result.put("records", parsed);
         }
-        System.out.println("Parsed records: " + parsed.size() + " for file " + uf.getId());
         logService.log(user, "上传文件 " + uf.getFileName(), "records=" + parsed.size());
         return result;
+    }
+
+    private java.util.Set<String> fetchExistingBarcodesFromChunk(java.util.Collection<WorkRecord> records) {
+        java.util.Set<String> codes = new java.util.LinkedHashSet<>();
+        for (WorkRecord wr : records) {
+            if (wr == null) {
+                continue;
+            }
+            String barcode = wr.getBarcode();
+            if (barcode == null) {
+                continue;
+            }
+            String trimmed = barcode.trim();
+            if (!trimmed.isEmpty()) {
+                codes.add(trimmed);
+            }
+        }
+        return fetchExistingBarcodes(codes);
+    }
+
+    private java.util.Set<String> fetchExistingBarcodes(java.util.Collection<String> barcodes) {
+        if (barcodes == null || barcodes.isEmpty()) {
+            return java.util.Collections.emptySet();
+        }
+        java.util.Set<String> unique = new java.util.LinkedHashSet<>();
+        for (String code : barcodes) {
+            if (code == null) {
+                continue;
+            }
+            String trimmed = code.trim();
+            if (!trimmed.isEmpty()) {
+                unique.add(trimmed);
+            }
+        }
+        if (unique.isEmpty()) {
+            return java.util.Collections.emptySet();
+        }
+        final int batchSize = 500;
+        java.util.Set<String> existing = new java.util.HashSet<>();
+        java.util.List<String> batch = new java.util.ArrayList<>(batchSize);
+        for (String code : unique) {
+            batch.add(code);
+            if (batch.size() == batchSize) {
+                existing.addAll(repository.findExistingBarcodes(batch));
+                batch.clear();
+            }
+        }
+        if (!batch.isEmpty()) {
+            existing.addAll(repository.findExistingBarcodes(batch));
+        }
+        return existing;
     }
 
     private List<WorkRecord> parseExcel(MultipartFile file, String password) throws IOException {

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -66,18 +66,24 @@ public class WorkRecordController {
 
     @GetMapping
     public List<WorkRecord> all() {
-        return repository.findAll();
+        List<WorkRecord> list = repository.findAll();
+        flagIssues(list);
+        return list;
     }
 
     @GetMapping("/barcode/{barcode}")
     public List<WorkRecord> byBarcode(@PathVariable String barcode) {
         String clean = sanitizeBarcode(barcode);
-        return repository.findByBarcode(clean);
+        List<WorkRecord> list = repository.findByBarcode(clean);
+        flagIssues(list);
+        return list;
     }
 
     @GetMapping("/file/{fileId}")
     public List<WorkRecord> byFile(@PathVariable Long fileId) {
-        return repository.findByFileId(fileId);
+        List<WorkRecord> list = repository.findByFileId(fileId);
+        flagIssues(list);
+        return list;
     }
 
     @GetMapping("/file/{fileId}/drawings")
@@ -105,12 +111,15 @@ public class WorkRecordController {
         Pageable pageable = PageRequest.of(Math.max(page, 0), pageSize);
         Page<WorkRecord> result = repository.findByFileIdAndDrawingNumber(fileId, drawing, pageable);
         result.forEach(r -> r.setBarcodeImage(null));
+        result.forEach(this::flagIssues);
         return result;
     }
 
     @GetMapping("/file/{fileId}/filled")
     public List<WorkRecord> byFileFilled(@PathVariable Long fileId) {
-        return repository.findByFileIdAndFilledTrue(fileId);
+        List<WorkRecord> list = repository.findByFileIdAndFilledTrue(fileId);
+        flagIssues(list);
+        return list;
     }
 
     @GetMapping("/file/{fileId}/export")
@@ -484,6 +493,7 @@ public class WorkRecordController {
                                      @RequestParam(value = "store", required = false, defaultValue = "true") boolean store,
                                      @RequestHeader("X-User") String user) throws IOException {
         List<WorkRecord> parsed = parseExcel(file, password);
+        flagIssues(parsed);
         int codeMissing = 0;
         int hoursMissing = 0;
         for (WorkRecord wr : parsed) {
@@ -555,6 +565,54 @@ public class WorkRecordController {
             }
         }
         return fetchExistingBarcodes(codes);
+    }
+
+    private void flagIssues(java.util.Collection<WorkRecord> records) {
+        if (records == null) {
+            return;
+        }
+        for (WorkRecord wr : records) {
+            flagIssues(wr);
+        }
+    }
+
+    private void flagIssues(WorkRecord wr) {
+        if (wr == null) {
+            return;
+        }
+        boolean notificationPresent = hasText(wr.getNotificationNumber());
+        wr.setNotificationMissing(!notificationPresent);
+
+        boolean productPresent = hasText(wr.getProductName());
+        wr.setProductMissing(!productPresent);
+
+        boolean partPresent = hasText(wr.getPartName());
+        wr.setPartMissing(!partPresent);
+
+        boolean drawingPresent = hasText(wr.getDrawingNumber());
+        wr.setDrawingMissing(!drawingPresent);
+
+        boolean planPresent = wr.getPlanQty() != null;
+        wr.setPlanMissing(!planPresent);
+
+        boolean processPresent = hasText(wr.getProcessName());
+        wr.setProcessMissing(!processPresent);
+
+        boolean hoursMissing = wr.getHours() == null;
+        wr.setHoursMissing(hoursMissing);
+
+        boolean codePresent = hasText(wr.getProcessCode());
+        boolean codeMissing = Boolean.TRUE.equals(wr.getCodeMissing()) || !codePresent;
+        wr.setCodeMissing(codeMissing);
+
+        String sanitizedBarcode = wr.getBarcode() != null ? sanitizeBarcode(wr.getBarcode()) : null;
+        boolean barcodePresent = hasText(sanitizedBarcode);
+        wr.setBarcode(sanitizedBarcode);
+        wr.setBarcodeMissing(!barcodePresent);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 
     private java.util.Set<String> fetchExistingBarcodes(java.util.Collection<String> barcodes) {

--- a/backend/src/main/java/com/example/worktime/controller/WorkTimeController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkTimeController.java
@@ -11,6 +11,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 
 @RestController
@@ -81,18 +83,43 @@ public class WorkTimeController {
         return saved;
     }
 
+    private final DataFormatter formatter = new DataFormatter(java.util.Locale.CHINA);
+    private static final DateTimeFormatter[] DATE_FORMATTERS = new DateTimeFormatter[] {
+            DateTimeFormatter.ISO_LOCAL_DATE,
+            DateTimeFormatter.BASIC_ISO_DATE,
+            DateTimeFormatter.ofPattern("yyyy/M/d", java.util.Locale.CHINA),
+            DateTimeFormatter.ofPattern("yyyy-M-d", java.util.Locale.CHINA),
+            DateTimeFormatter.ofPattern("yyyy.M.d", java.util.Locale.CHINA),
+            DateTimeFormatter.ofPattern("yyyy年M月d日", java.util.Locale.CHINA)
+    };
+
     private String getString(Row row, Integer index) {
         if (index == null) return null;
         Cell cell = row.getCell(index);
         if (cell == null) return null;
-        return cell.toString();
+        String value = formatter.formatCellValue(cell);
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private Double getDouble(Row row, Integer index) {
         if (index == null) return null;
         Cell cell = row.getCell(index);
         if (cell == null) return null;
-        return cell.getNumericCellValue();
+        String value = formatter.formatCellValue(cell);
+        if (value == null) return null;
+        String normalized = value.trim();
+        if (normalized.isEmpty()) return null;
+        normalized = normalized
+                .replace("，", ",")
+                .replace("．", ".")
+                .replaceAll("[ ,]", "");
+        try {
+            return new java.math.BigDecimal(normalized).doubleValue();
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     private LocalDate getDate(Row row, Integer index) {
@@ -102,7 +129,17 @@ public class WorkTimeController {
         if (DateUtil.isCellDateFormatted(cell)) {
             return cell.getLocalDateTimeCellValue().toLocalDate();
         }
-        return LocalDate.parse(cell.toString());
+        String value = getString(row, index);
+        if (value == null) {
+            return null;
+        }
+        for (DateTimeFormatter fmt : DATE_FORMATTERS) {
+            try {
+                return LocalDate.parse(value, fmt);
+            } catch (DateTimeParseException ignore) {
+            }
+        }
+        return null;
     }
 
     private void validate(WorkTime wt) {

--- a/backend/src/main/java/com/example/worktime/model/UploadedFile.java
+++ b/backend/src/main/java/com/example/worktime/model/UploadedFile.java
@@ -14,6 +14,7 @@ public class UploadedFile {
     private String fileName;
 
     @Lob
+    @Basic(fetch = FetchType.LAZY)
     @com.fasterxml.jackson.annotation.JsonIgnore
     private byte[] data;
 

--- a/backend/src/main/java/com/example/worktime/model/WorkRecord.java
+++ b/backend/src/main/java/com/example/worktime/model/WorkRecord.java
@@ -60,6 +60,27 @@ public class WorkRecord {
     @Transient
     private Boolean codeMissing;
 
+    @Transient
+    private Boolean notificationMissing;
+
+    @Transient
+    private Boolean productMissing;
+
+    @Transient
+    private Boolean drawingMissing;
+
+    @Transient
+    private Boolean planMissing;
+
+    @Transient
+    private Boolean processMissing;
+
+    @Transient
+    private Boolean barcodeMissing;
+
+    @Transient
+    private Boolean partMissing;
+
     // 单件工时
     private Double hours;
 
@@ -146,6 +167,27 @@ public class WorkRecord {
 
     public Boolean getCodeMissing() { return codeMissing; }
     public void setCodeMissing(Boolean codeMissing) { this.codeMissing = codeMissing; }
+
+    public Boolean getNotificationMissing() { return notificationMissing; }
+    public void setNotificationMissing(Boolean notificationMissing) { this.notificationMissing = notificationMissing; }
+
+    public Boolean getProductMissing() { return productMissing; }
+    public void setProductMissing(Boolean productMissing) { this.productMissing = productMissing; }
+
+    public Boolean getDrawingMissing() { return drawingMissing; }
+    public void setDrawingMissing(Boolean drawingMissing) { this.drawingMissing = drawingMissing; }
+
+    public Boolean getPlanMissing() { return planMissing; }
+    public void setPlanMissing(Boolean planMissing) { this.planMissing = planMissing; }
+
+    public Boolean getProcessMissing() { return processMissing; }
+    public void setProcessMissing(Boolean processMissing) { this.processMissing = processMissing; }
+
+    public Boolean getBarcodeMissing() { return barcodeMissing; }
+    public void setBarcodeMissing(Boolean barcodeMissing) { this.barcodeMissing = barcodeMissing; }
+
+    public Boolean getPartMissing() { return partMissing; }
+    public void setPartMissing(Boolean partMissing) { this.partMissing = partMissing; }
 
     public Double getHours() { return hours; }
     public void setHours(Double hours) { this.hours = hours; }

--- a/backend/src/main/java/com/example/worktime/repository/ProcessCodeRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/ProcessCodeRepository.java
@@ -2,10 +2,13 @@ package com.example.worktime.repository;
 
 import com.example.worktime.model.ProcessCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
 import java.util.List;
 
 public interface ProcessCodeRepository extends JpaRepository<ProcessCode, Long> {
     ProcessCode findByName(String name);
     ProcessCode findByCode(String code);
     List<ProcessCode> findByCodeContainingIgnoreCaseOrNameContainingIgnoreCase(String codePart, String namePart);
+    List<ProcessCode> findByNameIn(Collection<String> names);
 }

--- a/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
@@ -16,6 +16,8 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
 
     java.util.List<WorkRecord> findByDrawingNumber(String drawingNumber);
 
+    java.util.List<WorkRecord> findByDrawingNumberAndFilledTrue(String drawingNumber);
+
     @Query("select r from WorkRecord r where r.file.uploadTime >= :start and r.file.uploadTime < :end and r.filled = true")
     java.util.List<WorkRecord> findByUploadDate(@Param("start") java.time.LocalDateTime start,
                                                 @Param("end") java.time.LocalDateTime end);

--- a/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/WorkRecordRepository.java
@@ -34,4 +34,7 @@ public interface WorkRecordRepository extends JpaRepository<WorkRecord, Long> {
     Page<WorkRecord> findByNaturalMonthAndFilledTrue(String naturalMonth, Pageable pageable);
 
     java.util.List<WorkRecord> findByNaturalMonthAndFilledTrue(String naturalMonth);
+
+    @Query("select distinct r.barcode from WorkRecord r where r.barcode in :barcodes")
+    java.util.List<String> findExistingBarcodes(@Param("barcodes") java.util.Collection<String> barcodes);
 }

--- a/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
+++ b/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
@@ -4,6 +4,7 @@ import com.example.worktime.model.ProcessCode;
 import com.example.worktime.repository.ProcessCodeRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,5 +67,44 @@ public class ProcessCodeService {
             }
         }
         return null;
+    }
+
+    public Map<String, String> getCodes(Collection<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new HashMap<>();
+        List<String> pending = new java.util.ArrayList<>();
+        for (String raw : names) {
+            if (raw == null) {
+                continue;
+            }
+            String name = raw.trim();
+            if (name.isEmpty()) {
+                continue;
+            }
+            String cached = cache.get(name);
+            if (cached != null) {
+                result.put(name, cached);
+            } else {
+                pending.add(name);
+            }
+        }
+        if (!pending.isEmpty()) {
+            List<ProcessCode> found = repository.findByNameIn(pending);
+            for (ProcessCode pc : found) {
+                if (pc == null || pc.getName() == null || pc.getCode() == null) {
+                    continue;
+                }
+                String name = pc.getName().trim();
+                String code = pc.getCode().trim();
+                if (name.isEmpty() || code.isEmpty()) {
+                    continue;
+                }
+                cache.put(name, code);
+                result.put(name, code);
+            }
+        }
+        return result;
     }
 }

--- a/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
+++ b/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
@@ -2,7 +2,9 @@ package com.example.worktime.service;
 
 import com.example.worktime.model.ProcessCode;
 import com.example.worktime.repository.ProcessCodeRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -118,6 +120,10 @@ public class ProcessCodeService {
             return null;
         }
         ProcessCode existing = repository.findByName(trimmedName);
+        ProcessCode duplicate = repository.findByCode(trimmedCode);
+        if (duplicate != null && (existing == null || !duplicate.getId().equals(existing.getId()))) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "工序代号已存在，请使用其他代号");
+        }
         ProcessCode target;
         boolean created = false;
         if (existing != null) {

--- a/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
+++ b/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
@@ -107,4 +107,34 @@ public class ProcessCodeService {
         }
         return result;
     }
+
+    public ProcessCode rememberMapping(String name, String code) {
+        if (name == null || code == null) {
+            return null;
+        }
+        String trimmedName = name.trim();
+        String trimmedCode = code.trim();
+        if (trimmedName.isEmpty() || trimmedCode.isEmpty()) {
+            return null;
+        }
+        ProcessCode existing = repository.findByName(trimmedName);
+        ProcessCode target;
+        boolean created = false;
+        if (existing != null) {
+            existing.setCode(trimmedCode);
+            target = existing;
+        } else {
+            ProcessCode fresh = new ProcessCode();
+            fresh.setName(trimmedName);
+            fresh.setCode(trimmedCode);
+            target = fresh;
+            created = true;
+        }
+        ProcessCode saved = repository.save(target);
+        cache.put(trimmedName, trimmedCode);
+        if (!created && saved.getName() != null && !saved.getName().trim().isEmpty()) {
+            cache.put(saved.getName().trim(), trimmedCode);
+        }
+        return saved;
+    }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -31,10 +31,6 @@ export default {
     return { loggedIn: false }
   },
   created() {
-    window.addEventListener('beforeunload', () => {
-      localStorage.removeItem('loggedIn')
-      localStorage.removeItem('username')
-    })
     this.loggedIn = localStorage.getItem('loggedIn') === 'true'
   },
   methods: {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -18,15 +18,15 @@ body {
 .drawing-col { min-width: 120px; max-width: 150px; }
 .plan-col { width: 70px; max-width: 80px; }
 .hours-col { width: 80px; max-width: 90px; }
-.process-col { min-width: 100px; max-width: 140px; }
-.worker-code-col { min-width: 140px; }
-.qualified-col { min-width: 110px; }
-.time-col { min-width: 120px; }
-.inspector-col { min-width: 130px; }
+.process-col { min-width: 90px; max-width: 120px; }
+.worker-code-col { min-width: 160px; }
+.qualified-col { min-width: 140px; }
+.time-col { min-width: 140px; }
+.inspector-col { min-width: 150px; }
 
 /* Ensure barcode cells are tall enough so barcodes aren't clipped */
-.barcode-cell { min-width: 200px; min-height: 90px; }
-.barcode-cell img { display: block; height: 80px; width: auto; max-width: 280px; }
+.barcode-cell { min-width: 220px; min-height: 90px; }
+.barcode-cell img { display: block; height: 80px; width: auto; max-width: 320px; }
 
 /* allow table cells to wrap long text without widening the table */
 .wrap-text { white-space: pre-wrap; word-break: break-word; max-width: 320px; }
@@ -167,6 +167,8 @@ body {
   #preview-table .preview-page {
     margin-left: 0 !important;
     margin-right: 0 !important;
+    page-break-inside: avoid;
+    break-inside: avoid;
   }
 
   #preview-table table {
@@ -182,12 +184,22 @@ body {
   #preview-table .drawing-col { width: 140px; }
   #preview-table .plan-col { width: 70px; }
   #preview-table .hours-col { width: 80px; }
-  #preview-table .process-col { width: 110px; }
-  #preview-table .worker-code-col { width: 150px; }
-  #preview-table .qualified-col { width: 120px; }
-  #preview-table .time-col { width: 120px; }
-  #preview-table .inspector-col { width: 130px; }
-  #preview-table .barcode-cell { min-width: 180px; }
+  #preview-table .process-col { width: 95px; }
+  #preview-table .worker-code-col { width: 170px; }
+  #preview-table .qualified-col { width: 150px; }
+  #preview-table .time-col { width: 150px; }
+  #preview-table .inspector-col { width: 160px; }
+  #preview-table .barcode-cell { min-width: 210px; }
+
+  #preview-table .preview-page:not(:last-child) {
+    page-break-after: always;
+    break-after: page;
+  }
+
+  #preview-table .preview-page.force-new-page {
+    page-break-before: always;
+    break-before: page;
+  }
 
   #preview-table thead,
   #print-area thead { display: table-header-group; }
@@ -204,7 +216,7 @@ body {
   .print-page table { margin-bottom: 0 !important; }
 
   #preview-table .barcode-cell img,
-  #print-area .barcode-cell img { height: 80px; max-width: 280px; width: auto; }
+  #print-area .barcode-cell img { height: 80px; max-width: 320px; width: auto; }
   #print-area .barcode-cell div { word-break: break-all; }
 
   .blank-row { display: table-row !important; }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -14,18 +14,18 @@ body {
 
 .table th, .table td { vertical-align: middle; }
 
-.notification-col { min-width: 110px; max-width: 140px; }
-.drawing-col { min-width: 130px; max-width: 170px; }
-.plan-col { width: 80px; }
-.hours-col { width: 90px; }
-.process-col { min-width: 120px; max-width: 160px; }
-.worker-code-col { min-width: 120px; }
-.qualified-col { min-width: 90px; }
-.time-col { min-width: 130px; }
-.inspector-col { min-width: 120px; }
+.notification-col { min-width: 90px; max-width: 120px; }
+.drawing-col { min-width: 120px; max-width: 150px; }
+.plan-col { width: 70px; max-width: 80px; }
+.hours-col { width: 80px; max-width: 90px; }
+.process-col { min-width: 100px; max-width: 140px; }
+.worker-code-col { min-width: 140px; }
+.qualified-col { min-width: 110px; }
+.time-col { min-width: 120px; }
+.inspector-col { min-width: 130px; }
 
 /* Ensure barcode cells are tall enough so barcodes aren't clipped */
-.barcode-cell { min-width: 240px; min-height: 90px; }
+.barcode-cell { min-width: 200px; min-height: 90px; }
 .barcode-cell img { display: block; height: 80px; width: auto; max-width: 280px; }
 
 /* allow table cells to wrap long text without widening the table */
@@ -120,16 +120,23 @@ body {
 
   #preview-table table,
   #print-area table {
-    table-layout: auto;
+    table-layout: fixed;
     font-size: 10px;
     width: 100%;
   }
 
-  #preview-table th,
-  #preview-table td {
+  #preview-table th {
     white-space: nowrap;
     height: 26px;
     line-height: 26px;
+    vertical-align: middle;
+  }
+
+  #preview-table td {
+    white-space: normal;
+    word-break: break-word;
+    height: 26px;
+    line-height: 1.35;
     vertical-align: middle;
   }
 
@@ -142,6 +149,45 @@ body {
     vertical-align: middle;
     padding: 4px 6px;
   }
+
+  .container,
+  .container-fluid {
+    width: 100% !important;
+    max-width: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
+  #preview-table {
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+  }
+
+  #preview-table .preview-page {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  #preview-table table {
+    font-size: 11pt;
+  }
+
+  #preview-table thead th {
+    font-size: 13pt;
+    font-weight: 700;
+  }
+
+  #preview-table .notification-col { width: 100px; }
+  #preview-table .drawing-col { width: 140px; }
+  #preview-table .plan-col { width: 70px; }
+  #preview-table .hours-col { width: 80px; }
+  #preview-table .process-col { width: 110px; }
+  #preview-table .worker-code-col { width: 150px; }
+  #preview-table .qualified-col { width: 120px; }
+  #preview-table .time-col { width: 120px; }
+  #preview-table .inspector-col { width: 130px; }
+  #preview-table .barcode-cell { min-width: 180px; }
 
   #preview-table thead,
   #print-area thead { display: table-header-group; }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -14,6 +14,16 @@ body {
 
 .table th, .table td { vertical-align: middle; }
 
+.notification-col { min-width: 110px; max-width: 140px; }
+.drawing-col { min-width: 130px; max-width: 170px; }
+.plan-col { width: 80px; }
+.hours-col { width: 90px; }
+.process-col { min-width: 120px; max-width: 160px; }
+.worker-code-col { min-width: 120px; }
+.qualified-col { min-width: 90px; }
+.time-col { min-width: 130px; }
+.inspector-col { min-width: 120px; }
+
 /* Ensure barcode cells are tall enough so barcodes aren't clipped */
 .barcode-cell { min-width: 240px; min-height: 90px; }
 .barcode-cell img { display: block; height: 80px; width: auto; max-width: 280px; }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -128,8 +128,9 @@ body {
   }
 
   #preview-table th {
-    white-space: nowrap;
-    line-height: 1.4;
+    white-space: normal;
+    word-break: break-word;
+    line-height: 1.45;
     vertical-align: middle;
   }
 
@@ -176,13 +177,13 @@ body {
   }
 
   #preview-table thead th {
-    font-size: 13pt;
-    font-weight: 700;
+    font-size: 11.5pt;
+    font-weight: 600;
   }
 
   #preview-table thead th,
   #print-area thead th {
-    line-height: 1.6 !important;
+    line-height: 1.5 !important;
     padding-top: 6px !important;
     padding-bottom: 6px !important;
   }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -90,10 +90,9 @@ body {
 .issue-panel__drawing {
   font-weight: 500;
   font-size: .95rem;
-  max-width: 140px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .issue-panel__count {
@@ -118,6 +117,26 @@ body {
 .worker-code-col { min-width: 160px; }
 .qualified-col { min-width: 140px; }
 .time-col { min-width: 140px; }
+
+.bulk-issue-modal .modal-dialog {
+  max-width: 720px;
+}
+
+.bulk-issue-modal .modal-body {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.bulk-issue-modal__table thead th {
+  position: sticky;
+  top: 0;
+  background-color: #fff;
+  z-index: 1;
+}
+
+.bulk-issue-modal__table input.form-control-sm {
+  min-width: 120px;
+}
 .inspector-col { min-width: 150px; }
 
 /* Ensure barcode cells are tall enough so barcodes aren't clipped */

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -76,11 +76,15 @@ body {
   box-shadow: 0 0.25rem 0.5rem rgba(13,110,253,0.15);
 }
 
-.issue-panel__row {
+.issue-panel__row { 
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: .5rem;
+}
+
+.issue-panel__row--header {
+  align-items: flex-start;
 }
 
 .issue-panel__row--footer {
@@ -98,6 +102,24 @@ body {
 .issue-panel__count {
   font-size: .85rem;
   color: #6c757d;
+}
+
+.issue-panel__type-list {
+  margin-top: .5rem;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.issue-panel__type-row {
+  display: flex;
+  gap: .5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.issue-panel__type-button {
+  min-width: 0;
 }
 
 .issue-filter-alert {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -180,6 +180,13 @@ body {
     font-weight: 700;
   }
 
+  #preview-table thead th,
+  #print-area thead th {
+    line-height: 1.6 !important;
+    padding-top: 6px !important;
+    padding-bottom: 6px !important;
+  }
+
   #preview-table .notification-col,
   #preview-table .drawing-col,
   #preview-table .plan-col,

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -31,6 +31,15 @@ body {
 /* allow table cells to wrap long text without widening the table */
 .wrap-text { white-space: pre-wrap; word-break: break-word; max-width: 320px; }
 
+.missing-cell {
+  background-color: #fff3cd !important;
+}
+
+.issue-tag {
+  font-size: .75rem;
+  color: #dc3545;
+}
+
 /* wider inputs for worker allocations */
 .alloc-input { width: 90px; }
 

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -25,11 +25,11 @@ body {
 .inspector-col { min-width: 150px; }
 
 /* Ensure barcode cells are tall enough so barcodes aren't clipped */
-.barcode-cell { min-width: 220px; min-height: 90px; }
+.barcode-cell { min-width: 150px; }
 .barcode-cell img {
   display: block;
   height: auto;
-  max-height: 80px;
+  max-height: 70px;
   width: 100%;
 }
 
@@ -93,9 +93,6 @@ body {
 .print-title { font-weight: 600; font-size: 1.1rem; }
 .print-meta { font-size: .9rem; color: #6c757d; }
 
-.blank-row { display: table-row; background-color: #fdfdfd; }
-.blank-row td { min-height: 24px; }
-
 /* ===================== PRINT ===================== */
 @media print {
   .screen-only { display: none !important; }
@@ -132,15 +129,13 @@ body {
 
   #preview-table th {
     white-space: nowrap;
-    height: 26px;
-    line-height: 26px;
+    line-height: 1.4;
     vertical-align: middle;
   }
 
   #preview-table td {
     white-space: normal;
     word-break: break-word;
-    height: 26px;
     line-height: 1.35;
     vertical-align: middle;
   }
@@ -224,25 +219,16 @@ body {
   #preview-table tr,
   #print-area tr { page-break-inside: avoid; break-inside: avoid; }
 
-  #print-area .blank-row td {
-    padding-top: 2px;
-    padding-bottom: 2px;
-    line-height: 1.1;
-    min-height: 20px;
-  }
-
   .print-page table { margin-bottom: 0 !important; }
 
   #preview-table .barcode-cell img,
   #print-area .barcode-cell img {
     height: auto;
-    max-height: 80px;
+    max-height: 70px;
     max-width: 100%;
     width: 100%;
   }
   #print-area .barcode-cell div { word-break: break-all; }
-
-  .blank-row { display: table-row !important; }
 
   .print-page { break-after: page; page-break-after: always; }
   .print-page:last-child { break-after: auto; page-break-after: auto; }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -26,7 +26,12 @@ body {
 
 /* Ensure barcode cells are tall enough so barcodes aren't clipped */
 .barcode-cell { min-width: 220px; min-height: 90px; }
-.barcode-cell img { display: block; height: 80px; width: auto; max-width: 320px; }
+.barcode-cell img {
+  display: block;
+  height: auto;
+  max-height: 80px;
+  width: 100%;
+}
 
 /* allow table cells to wrap long text without widening the table */
 .wrap-text { white-space: pre-wrap; word-break: break-word; max-width: 320px; }
@@ -180,16 +185,29 @@ body {
     font-weight: 700;
   }
 
-  #preview-table .notification-col { width: 100px; }
-  #preview-table .drawing-col { width: 140px; }
-  #preview-table .plan-col { width: 70px; }
-  #preview-table .hours-col { width: 80px; }
-  #preview-table .process-col { width: 95px; }
-  #preview-table .worker-code-col { width: 170px; }
-  #preview-table .qualified-col { width: 150px; }
-  #preview-table .time-col { width: 150px; }
-  #preview-table .inspector-col { width: 160px; }
-  #preview-table .barcode-cell { min-width: 210px; }
+  #preview-table .notification-col,
+  #preview-table .drawing-col,
+  #preview-table .plan-col,
+  #preview-table .hours-col,
+  #preview-table .process-col,
+  #preview-table .worker-code-col,
+  #preview-table .qualified-col,
+  #preview-table .time-col,
+  #preview-table .inspector-col,
+  #preview-table .barcode-cell {
+    min-width: 0 !important;
+  }
+
+  #preview-table .notification-col { width: 8% !important; }
+  #preview-table .drawing-col { width: 10% !important; }
+  #preview-table .plan-col { width: 4% !important; }
+  #preview-table .hours-col { width: 6% !important; }
+  #preview-table .process-col { width: 8% !important; }
+  #preview-table .worker-code-col { width: 12% !important; }
+  #preview-table .qualified-col { width: 8% !important; }
+  #preview-table .time-col { width: 9% !important; }
+  #preview-table .inspector-col { width: 9% !important; }
+  #preview-table .barcode-cell { width: 17% !important; }
 
   #preview-table .preview-page:not(:last-child) {
     page-break-after: always;
@@ -216,7 +234,12 @@ body {
   .print-page table { margin-bottom: 0 !important; }
 
   #preview-table .barcode-cell img,
-  #print-area .barcode-cell img { height: 80px; max-width: 320px; width: auto; }
+  #print-area .barcode-cell img {
+    height: auto;
+    max-height: 80px;
+    max-width: 100%;
+    width: 100%;
+  }
   #print-area .barcode-cell div { word-break: break-all; }
 
   .blank-row { display: table-row !important; }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -90,9 +90,15 @@ body {
   .print-text { display: inline !important; }
   .print-only { display: table-cell !important; }
 
-  .navbar,
-  .section-card {
+  .navbar {
     display: none !important;
+  }
+
+  .section-card {
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
   }
 
   #preview-table,

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -12,6 +12,102 @@ body {
   box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.075);
 }
 
+.upload-preview-layout {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.preview-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.issue-panel {
+  position: sticky;
+  top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: .5rem;
+  padding: 1rem;
+  box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.05);
+  min-width: 230px;
+  max-width: 260px;
+}
+
+.issue-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+}
+
+.issue-panel__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.issue-panel__empty {
+  padding: .25rem 0;
+}
+
+.issue-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.issue-panel__item {
+  border: 1px solid #f1f3f5;
+  border-radius: .5rem;
+  padding: .75rem;
+  background-color: #fdfdfd;
+  transition: border-color .2s ease, box-shadow .2s ease;
+}
+
+.issue-panel__item--active {
+  border-color: #0d6efd;
+  box-shadow: 0 0.25rem 0.5rem rgba(13,110,253,0.15);
+}
+
+.issue-panel__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+}
+
+.issue-panel__row--footer {
+  margin-top: .5rem;
+}
+
+.issue-panel__drawing {
+  font-weight: 500;
+  font-size: .95rem;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issue-panel__count {
+  font-size: .85rem;
+  color: #6c757d;
+}
+
+.issue-filter-alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+}
+
 .table th, .table td { vertical-align: middle; }
 
 .notification-col { min-width: 90px; max-width: 120px; }
@@ -53,6 +149,23 @@ body {
 
 /* highlight editable fields so they stand out against table background */
 .edit-highlight { background-color: #fffbe6; border-color: #f0ad4e; }
+
+
+@media (max-width: 991.98px) {
+  .upload-preview-layout {
+    flex-direction: column;
+  }
+
+  .issue-panel {
+    position: static;
+    width: 100%;
+    max-width: none;
+  }
+
+  .issue-panel__drawing {
+    max-width: none;
+  }
+}
 
 
 .upload-toolbar {

--- a/frontend/src/components/BulkIssueModal.vue
+++ b/frontend/src/components/BulkIssueModal.vue
@@ -1,0 +1,143 @@
+<template>
+  <teleport to="body">
+    <div
+      v-if="visible"
+      class="modal fade show d-block bulk-issue-modal"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div class="modal-dialog modal-lg modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">批量处理：{{ title }}</h5>
+            <button type="button" class="btn-close" @click="$emit('close')" aria-label="关闭"></button>
+          </div>
+          <div class="modal-body">
+            <p class="text-muted small mb-3">
+              一次性快速填写当前筛选出的记录，可逐条调整后统一保存。
+            </p>
+            <div class="table-responsive">
+              <table class="table table-sm bulk-issue-modal__table align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th style="min-width: 120px;">通知单号</th>
+                    <th style="min-width: 140px;">图号</th>
+                    <th style="min-width: 140px;">工序</th>
+                    <th v-if="type === '工序代码'" style="min-width: 140px;">工序代码</th>
+                    <th v-else-if="type === '单件工时'" style="min-width: 120px;">单件工时</th>
+                    <th v-else-if="type === '工序'" style="min-width: 140px;">工序名称</th>
+                    <th v-else-if="type === '计划数'" style="min-width: 120px;">计划数</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="item in drafts" :key="item.index">
+                    <td>{{ item.notificationNumber || '—' }}</td>
+                    <td>{{ item.drawingNumber || '—' }}</td>
+                    <td>{{ item.processName || '—' }}</td>
+                    <td v-if="type === '工序代码'">
+                      <input
+                        type="text"
+                        class="form-control form-control-sm"
+                        v-model.trim="item.processCode"
+                        placeholder="填写工序代码"
+                      >
+                    </td>
+                    <td v-else-if="type === '单件工时'">
+                      <input
+                        type="number"
+                        step="0.0001"
+                        class="form-control form-control-sm"
+                        v-model.number="item.hours"
+                        placeholder="输入工时"
+                      >
+                    </td>
+                    <td v-else-if="type === '工序'">
+                      <input
+                        type="text"
+                        class="form-control form-control-sm"
+                        v-model.trim="item.processName"
+                        placeholder="输入工序名称"
+                      >
+                    </td>
+                    <td v-else-if="type === '计划数'">
+                      <input
+                        type="number"
+                        class="form-control form-control-sm"
+                        v-model.number="item.planQty"
+                        placeholder="输入计划数"
+                      >
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" @click="$emit('close')">取消</button>
+            <button type="button" class="btn btn-primary" @click="submit">应用修改</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div v-if="visible" class="modal-backdrop fade show"></div>
+  </teleport>
+</template>
+
+<script>
+export default {
+  name: 'BulkIssueModal',
+  props: {
+    visible: { type: Boolean, default: false },
+    type: { type: String, default: '' },
+    group: { type: Object, default: null },
+    records: { type: Array, default: () => [] }
+  },
+  data() {
+    return { drafts: [] }
+  },
+  computed: {
+    title() {
+      const drawing = this.group && this.group.drawingNumber
+      const drawingLabel = drawing ? `图号「${drawing}」` : '无图号'
+      return `${drawingLabel}缺少「${this.type}」`
+    }
+  },
+  watch: {
+    visible: {
+      handler(val) {
+        if (val) {
+          this.initialiseDrafts()
+        } else {
+          this.drafts = []
+        }
+      },
+      immediate: true
+    },
+    records: {
+      handler() {
+        if (this.visible) this.initialiseDrafts()
+      },
+      deep: true
+    }
+  },
+  methods: {
+    initialiseDrafts() {
+      const payload = Array.isArray(this.records) ? this.records : []
+      this.drafts = payload.map(item => ({
+        index: item.index,
+        notificationNumber: item.notificationNumber,
+        drawingNumber: item.drawingNumber,
+        processName: item.processName,
+        processCode: item.processCode,
+        hours: item.hours,
+        planQty: item.planQty
+      }))
+    },
+    submit() {
+      const updates = this.drafts.map(item => ({ ...item }))
+      this.$emit('apply', { type: this.type, updates })
+    }
+  }
+}
+</script>

--- a/frontend/src/components/ProcessManager.vue
+++ b/frontend/src/components/ProcessManager.vue
@@ -94,21 +94,69 @@ export default {
       const url = term
         ? `/api/processcodes/search?term=${encodeURIComponent(term)}`
         : '/api/processcodes'
-      const res = await axios.get(url)
-      this.processCodes = res.data
+      try {
+        const res = await axios.get(url)
+        this.processCodes = res.data
+      } catch (error) {
+        this.showError(error, '加载工序代码失败')
+      }
     },
     async createProcess() {
-      await axios.post('/api/processcodes', this.newProcess)
-      this.closeModal()
-      this.fetchProcesses(this.search)
+      try {
+        await axios.post('/api/processcodes', this.newProcess)
+        this.closeModal()
+        this.fetchProcesses(this.search)
+      } catch (error) {
+        this.showError(error, '新增工序代码失败')
+      }
     },
     async updateProcess(p) {
-      await axios.put(`/api/processcodes/${p.id}`, p)
-      this.fetchProcesses(this.search)
+      try {
+        await axios.put(`/api/processcodes/${p.id}`, p)
+        this.fetchProcesses(this.search)
+      } catch (error) {
+        this.showError(error, '更新工序代码失败')
+      }
     },
     async deleteProcess(id) {
-      await axios.delete(`/api/processcodes/${id}`)
-      this.fetchProcesses(this.search)
+      try {
+        await axios.delete(`/api/processcodes/${id}`)
+        this.fetchProcesses(this.search)
+      } catch (error) {
+        this.showError(error, '删除工序代码失败')
+      }
+    },
+    showError(error, fallback) {
+      console.error(error)
+      const response = error && error.response
+      let message = null
+      if (response && response.data != null) {
+        const data = response.data
+        if (typeof data === 'string') {
+          message = data
+        } else if (typeof data === 'object') {
+          message = data.message || data.error || data.detail || null
+          if (!message && Array.isArray(data.errors) && data.errors.length) {
+            const first = data.errors[0]
+            message = typeof first === 'string' ? first : (first && first.message) || null
+          }
+        }
+      }
+      if (!message && response && response.status === 409) {
+        const url = response.config && response.config.url ? String(response.config.url) : ''
+        if (url.includes('/api/processcodes')) {
+          message = '工序代码已存在，请使用其他代号'
+        } else {
+          message = '请求冲突，请检查数据后重试'
+        }
+      }
+      if (!message && response && typeof response.statusText === 'string' && response.statusText) {
+        message = response.statusText
+      }
+      if (!message && error && typeof error.message === 'string') {
+        message = error.message
+      }
+      alert(message || fallback || '操作失败')
     }
   }
 }

--- a/frontend/src/components/RecordIssuePanel.vue
+++ b/frontend/src/components/RecordIssuePanel.vue
@@ -12,26 +12,36 @@
     <p v-if="!groups.length" class="issue-panel__empty text-muted small mb-0">当前没有缺陷记录。</p>
     <ul v-else class="issue-panel__list list-unstyled mb-0">
       <li
-        v-for="group in groups"
-        :key="group.key"
-        :class="['issue-panel__item', { 'issue-panel__item--active': activeGroup && activeGroup.key === group.key }]"
+        v-for="bucket in buckets"
+        :key="bucket.key"
+        :class="['issue-panel__item', { 'issue-panel__item--active': bucket.hasActive }]"
       >
-        <div class="issue-panel__row">
-          <span class="issue-panel__drawing" :title="group.drawingNumber || '（空图号）'">{{ group.drawingNumber || '（空图号）' }}</span>
-          <span class="badge bg-danger-subtle text-danger">缺少{{ group.type }}</span>
+        <div class="issue-panel__row issue-panel__row--header">
+          <span class="issue-panel__drawing" :title="bucket.title">{{ bucket.title }}</span>
+          <span class="issue-panel__count">共 {{ bucket.total }} 条缺陷</span>
         </div>
-        <div class="issue-panel__row issue-panel__row--footer">
-          <span class="issue-panel__count">{{ group.count }} 条</span>
-          <div class="btn-group btn-group-sm">
-            <button type="button" class="btn btn-outline-primary" @click="$emit('select', group)">定位</button>
+        <ul class="issue-panel__type-list list-unstyled mb-0">
+          <li
+            v-for="item in bucket.items"
+            :key="item.group.key"
+            class="issue-panel__type-row"
+          >
             <button
-              v-if="bulkableTypes.includes(group.type)"
               type="button"
-              class="btn btn-outline-success"
-              @click="$emit('bulk', group)"
+              class="issue-panel__type-button btn btn-sm"
+              :class="item.isActive ? 'btn-primary' : 'btn-outline-primary'"
+              @click="$emit('select', item.group)"
+            >
+              缺少{{ item.group.type }}（{{ item.group.count }}）
+            </button>
+            <button
+              v-if="bulkableTypes.includes(item.group.type)"
+              type="button"
+              class="btn btn-sm btn-outline-success"
+              @click="$emit('bulk', item.group)"
             >批量填写</button>
-          </div>
-        </div>
+          </li>
+        </ul>
       </li>
     </ul>
   </aside>
@@ -52,6 +62,41 @@ export default {
     bulkableTypes: {
       type: Array,
       default: () => ['工序代码', '工序', '单件工时', '计划数']
+    }
+  },
+  computed: {
+    buckets() {
+      if (!this.groups || !this.groups.length) {
+        return []
+      }
+      const byDrawing = new Map()
+      const order = []
+      this.groups.forEach(group => {
+        const drawingKey = group.drawingNumber || ''
+        let bucket = byDrawing.get(drawingKey)
+        if (!bucket) {
+          bucket = {
+            key: `${drawingKey}|||bucket`,
+            drawingNumber: group.drawingNumber || '',
+            title: group.drawingNumber || '（空图号）',
+            total: 0,
+            hasActive: false,
+            items: []
+          }
+          byDrawing.set(drawingKey, bucket)
+          order.push(bucket)
+        }
+        bucket.total += group.count
+        const isActive = this.activeGroup && this.activeGroup.key === group.key
+        if (isActive) {
+          bucket.hasActive = true
+        }
+        bucket.items.push({
+          group,
+          isActive
+        })
+      })
+      return order
     }
   }
 }

--- a/frontend/src/components/RecordIssuePanel.vue
+++ b/frontend/src/components/RecordIssuePanel.vue
@@ -1,0 +1,58 @@
+<template>
+  <aside class="issue-panel">
+    <header class="issue-panel__header">
+      <h3 class="issue-panel__title">缺陷追踪</h3>
+      <button
+        v-if="activeGroup"
+        type="button"
+        class="btn btn-sm btn-outline-secondary"
+        @click="$emit('clear')"
+      >退出筛选</button>
+    </header>
+    <p v-if="!groups.length" class="issue-panel__empty text-muted small mb-0">当前没有缺陷记录。</p>
+    <ul v-else class="issue-panel__list list-unstyled mb-0">
+      <li
+        v-for="group in groups"
+        :key="group.key"
+        :class="['issue-panel__item', { 'issue-panel__item--active': activeGroup && activeGroup.key === group.key }]"
+      >
+        <div class="issue-panel__row">
+          <span class="issue-panel__drawing">{{ group.drawingNumber || '（空图号）' }}</span>
+          <span class="badge bg-danger-subtle text-danger">缺少{{ group.type }}</span>
+        </div>
+        <div class="issue-panel__row issue-panel__row--footer">
+          <span class="issue-panel__count">{{ group.count }} 条</span>
+          <div class="btn-group btn-group-sm">
+            <button type="button" class="btn btn-outline-primary" @click="$emit('select', group)">定位</button>
+            <button
+              v-if="bulkableTypes.includes(group.type)"
+              type="button"
+              class="btn btn-outline-success"
+              @click="$emit('bulk', group)"
+            >批量填写</button>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </aside>
+</template>
+
+<script>
+export default {
+  name: 'RecordIssuePanel',
+  props: {
+    groups: {
+      type: Array,
+      default: () => []
+    },
+    activeGroup: {
+      type: Object,
+      default: null
+    },
+    bulkableTypes: {
+      type: Array,
+      default: () => ['工序代码', '工序', '单件工时', '计划数']
+    }
+  }
+}
+</script>

--- a/frontend/src/components/RecordIssuePanel.vue
+++ b/frontend/src/components/RecordIssuePanel.vue
@@ -17,7 +17,7 @@
         :class="['issue-panel__item', { 'issue-panel__item--active': activeGroup && activeGroup.key === group.key }]"
       >
         <div class="issue-panel__row">
-          <span class="issue-panel__drawing">{{ group.drawingNumber || '（空图号）' }}</span>
+          <span class="issue-panel__drawing" :title="group.drawingNumber || '（空图号）'">{{ group.drawingNumber || '（空图号）' }}</span>
           <span class="badge bg-danger-subtle text-danger">缺少{{ group.type }}</span>
         </div>
         <div class="issue-panel__row issue-panel__row--footer">

--- a/frontend/src/components/RecordScanner.vue
+++ b/frontend/src/components/RecordScanner.vue
@@ -273,10 +273,6 @@ export default {
       }
     },
     async updateRecord(rec) {
-      const total = this.records.reduce((sum, r) => sum + (r === rec ? (rec.qualifiedQty || 0) : (r.qualifiedQty || 0)), 0)
-      if (this.planQty != null && total > this.planQty) {
-        alert('总合格数已超过计划数，请确认')
-      }
       const qtyOk = this.validateQtyAllocation(rec)
       const hourOk = this.validateHourAllocation(rec)
       if (!qtyOk || !hourOk) return
@@ -296,8 +292,6 @@ export default {
     },
     async saveAllRecords() {
       if (!this.records.length || this.viewOnly) return
-      const planOk = this.validatePlanQty()
-      if (!planOk) return
       let valid = true
       for (const rec of this.records) {
         const qtyOk = this.validateQtyAllocation(rec)
@@ -421,14 +415,7 @@ export default {
     onHourFieldsInput(rec) {
       this.computeQtysFromHours(rec)
     },
-    validatePlanQty() {
-      const total = this.records.reduce((sum, r) => sum + (r.qualifiedQty || 0), 0)
-      if (this.planQty != null && total > this.planQty) {
-        alert('总合格数已超过计划数，请确认')
-        return false
-      }
-      return true
-    },
+    validatePlanQty() { return true },
     validateQtyAllocation(rec) {
       if (!rec || !Array.isArray(rec.workerQtyVals)) return true
       const sum = rec.workerQtyVals.reduce((a, b) => a + (parseFloat(b) || 0), 0)
@@ -457,7 +444,6 @@ export default {
     },
     updatePlanQty() {
       this.records.forEach(r => { r.planQty = this.planQtyInput })
-      this.validatePlanQty()
     },
     async lookupWorker(rec) {
       const codes = rec.workerCodes ? rec.workerCodes.split(/[,\u3001\s]+/) : []

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -39,12 +39,12 @@
       </div>
 
       <!-- 保持不变：force-new-page 确保新图号必换页 -->
-      <div
-        v-for="(page, pageIndex) in pages"
-        :key="pageIndex"
-        class="preview-page"
-        :class="{ 'active-page': pageIndex === currentPage, 'force-new-page': page.isFirstOfDrawing && pageIndex !== 0 }"
-      >
+      <template v-for="(page, pageIndex) in pages" :key="pageIndex">
+        <div
+          v-if="shouldRenderPage(pageIndex)"
+          class="preview-page"
+          :class="{ 'active-page': pageIndex === currentPage, 'force-new-page': page.isFirstOfDrawing && pageIndex !== 0 }"
+        >
         <div class="d-flex justify-content-between align-items-center mb-2 page-heading">
           <h3 class="h6 mb-0">图号：{{ page.drawingNumber || '（空）' }}</h3>
           <span class="text-muted">第 {{ pageIndex + 1 }} 页 / 共 {{ pages.length }} 页</span>
@@ -128,7 +128,8 @@
             </tr>
           </tbody>
         </table>
-      </div>
+        </div>
+      </template>
     </div>
   </section>
 </template>
@@ -151,7 +152,9 @@ export default {
       processCacheLoaded: false,
       barcodeCache: {},
       showProgress: false,
-      parseProgress: 0
+      parseProgress: 0,
+      renderAllPages: false,
+      renderBuffer: 1
     }
   },
   created() {
@@ -372,16 +375,18 @@ export default {
       if (!this.preview.length) return
       this.loading = true
       try {
-        for (let i = 0; i < this.pages.length; i++) {
-          // eslint-disable-next-line no-await-in-loop
-          await this.loadBarcodesForPage(i)
-        }
+        await this.prefetchAllBarcodes()
       } finally { this.loading = false }
       const title = document.title
       if (this.currentFileName) document.title = this.currentFileName
-      await this.$nextTick()
-      window.print()
-      document.title = title
+      this.renderAllPages = true
+      try {
+        await this.$nextTick()
+        window.print()
+      } finally {
+        this.renderAllPages = false
+        document.title = title
+      }
     },
     sanitize(text) {
       if (!text) return ''
@@ -482,24 +487,20 @@ export default {
           this.$set(entry.record, 'barcode', code)
         }
         if (!code) continue
-        if (this.barcodeCache[code]) {
-          if (entry.record.barcodeImage !== this.barcodeCache[code]) {
+        if (!this.barcodeCache[code] && !entry.record.barcodeImage) missing.push(code)
+      }
+      if (!missing.length) {
+        for (const entry of page.entries) {
+          const code = this.sanitize(entry.record.barcode)
+          if (code && this.barcodeCache[code] && entry.record.barcodeImage !== this.barcodeCache[code]) {
             this.$set(entry.record, 'barcodeImage', this.barcodeCache[code])
           }
-        } else if (!entry.record.barcodeImage) {
-          missing.push(code)
         }
+        return
       }
-      if (!missing.length) return
-      const unique = Array.from(new Set(missing))
       this._barcodeLoading.add(pageIndex)
       try {
-        const res = await axios.post('/api/workrecords/generateBarcodes', unique)
-        const data = res && res.data ? res.data : {}
-        Object.keys(data || {}).forEach(key => {
-          if (!key) return
-          this.$set(this.barcodeCache, key, data[key])
-        })
+        await this.fetchBarcodes(missing)
         for (const entry of page.entries) {
           const code = this.sanitize(entry.record.barcode)
           if (code && this.barcodeCache[code]) {
@@ -508,6 +509,51 @@ export default {
         }
       } catch (e) { console.error('加载条码失败', e) }
       finally { this._barcodeLoading.delete(pageIndex) }
+    },
+    async fetchBarcodes(codes) {
+      if (!Array.isArray(codes) || !codes.length) return
+      const unique = []
+      const seen = new Set()
+      for (const raw of codes) {
+        const code = this.sanitize(raw)
+        if (!code) continue
+        if (this.barcodeCache[code]) continue
+        if (seen.has(code)) continue
+        seen.add(code)
+        unique.push(code)
+      }
+      if (!unique.length) return
+      const chunkSize = 250
+      for (let offset = 0; offset < unique.length; offset += chunkSize) {
+        const chunk = unique.slice(offset, offset + chunkSize)
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const res = await axios.post('/api/workrecords/generateBarcodes', chunk)
+          const data = res && res.data ? res.data : {}
+          Object.keys(data || {}).forEach(key => {
+            if (!key) return
+            this.$set(this.barcodeCache, key, data[key])
+          })
+        } catch (error) {
+          console.error('批量生成条码失败', error)
+          break
+        }
+      }
+    },
+    async prefetchAllBarcodes() {
+      const codes = []
+      for (const record of this.preview) {
+        const code = this.sanitize(record.barcode)
+        if (!code) continue
+        codes.push(code)
+      }
+      await this.fetchBarcodes(codes)
+      for (const record of this.preview) {
+        const code = this.sanitize(record.barcode)
+        if (code && this.barcodeCache[code] && record.barcodeImage !== this.barcodeCache[code]) {
+          this.$set(record, 'barcodeImage', this.barcodeCache[code])
+        }
+      }
     },
     async refreshProcesses() {
       await this.ensureProcessCache()
@@ -563,6 +609,10 @@ export default {
       if (!this.pages.length) { this.currentPage = 0; return }
       if (this.currentPage >= this.pages.length) this.currentPage = this.pages.length - 1
       if (this.currentPage < 0) this.currentPage = 0
+    },
+    shouldRenderPage(index) {
+      if (this.renderAllPages) return true
+      return Math.abs(index - this.currentPage) <= this.renderBuffer
     }
   }
 }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="section-card">
-    <h2 class="h5">Excel上传</h2>
+    <h2 class="h5 no-print">Excel上传</h2>
     <div class="input-group mb-2 no-print">
       <input class="form-control" type="file" @change="onFileChange">
       <button class="btn btn-outline-primary" @click="parse" :disabled="!file">解析</button>
@@ -258,6 +258,8 @@ export default {
       record.productName = record.productName != null ? String(record.productName).trim() : ''
       record.drawingNumber = record.drawingNumber != null ? String(record.drawingNumber).trim() : ''
       record.partName = record.partName != null ? String(record.partName).trim() : ''
+      record.processName = record.processName != null ? String(record.processName).trim() : ''
+      record.processCode = record.processCode != null ? String(record.processCode).trim() : ''
       if (record.planQty !== null && record.planQty !== undefined && record.planQty !== '') {
         const num = Number(record.planQty)
         record.planQty = Number.isNaN(num) ? null : num
@@ -270,12 +272,15 @@ export default {
       } else {
         record.hours = null
       }
-      record.barcode = this.sanitize(record.barcode)
+      const rawBarcode = record.barcode != null ? String(record.barcode).trim() : ''
+      record.barcode = this.sanitize(rawBarcode)
       record.barcodeImage = record.barcodeImage || ''
       record.workerCodes = record.workerCodes || ''
       record.qualifiedQty = record.qualifiedQty != null ? Number(record.qualifiedQty) : null
       record.hourSubtotal = record.hourSubtotal != null ? Number(record.hourSubtotal) : null
-      record.codeMissing = record.codeMissing === true
+      const sourceCodeMissing = record.codeMissing === true
+      record.codeMissing = sourceCodeMissing
+      record.serverCodeMissing = sourceCodeMissing
       record.hoursMissing = record.hoursMissing === true
       record.notificationMissing = record.notificationMissing === true
       record.productMissing = record.productMissing === true
@@ -314,7 +319,11 @@ export default {
       if (record.hoursMissing) issues.push('单件工时')
 
       const hasProcessCode = this.hasText(record.processCode)
-      record.codeMissing = record.codeMissing === true || !hasProcessCode
+      const codeMissingFlag = record.serverCodeMissing === true || !hasProcessCode
+      if (!codeMissingFlag) {
+        record.serverCodeMissing = false
+      }
+      record.codeMissing = codeMissingFlag
       if (record.codeMissing) issues.push('工序代码')
 
       const sanitizedBarcode = this.hasText(record.barcode) ? this.sanitize(String(record.barcode)) : ''
@@ -517,8 +526,9 @@ export default {
       this.renderAllPages = false
     },
     sanitize(text) {
-      if (!text) return ''
-      const source = typeof text.normalize === 'function' ? text.normalize('NFKC') : text
+      if (text === null || text === undefined) return ''
+      const sourceText = String(text)
+      const source = typeof sourceText.normalize === 'function' ? sourceText.normalize('NFKC') : sourceText
       const invis = /\p{C}/u
       const whitespace = /\s/u
       let result = ''
@@ -550,6 +560,7 @@ export default {
       if (!record) return
       record.processCode = ''
       record.codeMissing = true
+      record.serverCodeMissing = false
       record.barcode = ''
       record.barcodeImage = ''
       this.updateIssueFlags(record)
@@ -560,8 +571,17 @@ export default {
     },
     async updateProcess(r, cacheReady = false, allowFetch = true, fetchBarcodeImage = true) {
       if (!cacheReady) await this.ensureProcessCache()
-      const rawName = r.processName || ''; const name = rawName.trim()
-      if (!name) { r.processCode = ''; r.codeMissing = true; await this.updateBarcode(r, fetchBarcodeImage); return }
+      const rawName = r.processName || ''
+      const name = rawName.trim()
+      const existingCode = r.processCode != null ? String(r.processCode).trim() : ''
+      if (!name) {
+        r.processCode = ''
+        r.serverCodeMissing = false
+        r.codeMissing = true
+        await this.updateBarcode(r, fetchBarcodeImage)
+        this.updateIssueFlags(r)
+        return
+      }
       let code = this.processCache[name]
       if (!code && allowFetch) {
         try {
@@ -572,7 +592,16 @@ export default {
           }
         } catch (e) { /* ignore */ }
       }
-      if (code) { r.processCode = code; r.codeMissing = false } else { r.processCode = rawName; r.codeMissing = true }
+      if (code) {
+        r.processCode = code
+        r.serverCodeMissing = false
+      } else if (existingCode && r.serverCodeMissing !== true) {
+        r.processCode = existingCode
+      } else {
+        r.processCode = ''
+        r.serverCodeMissing = true
+      }
+      r.codeMissing = !this.hasText(r.processCode) || r.serverCodeMissing === true
       await this.updateBarcode(r, fetchBarcodeImage)
       this.updateIssueFlags(r)
     },

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -296,10 +296,12 @@ export default {
       catch (err) { return }
       this.loading = true; this.showProgress = true; this.parseProgress = 5; this.barcodeCache = {}
       try {
-        const data = new FormData(); data.append('file', this.file)
+        const data = new FormData(); data.append('file', this.file); data.append('store', 'false')
         const res = await axios.post('/api/workrecords/parse', data, { headers })
-        this.fileId = res.data.fileId
-        const records = Array.isArray(res.data.records) ? res.data.records : []
+        const payload = res && res.data ? res.data : {}
+        this.fileId = payload.fileId
+        this.selectedFileId = payload.fileId || ''
+        const records = Array.isArray(payload.records) ? payload.records : []
         const processed = []; const total = records.length
         if (!total) this.parseProgress = 100
         for (let i = 0; i < records.length; i++) {
@@ -381,7 +383,19 @@ export default {
       window.print()
       document.title = title
     },
-    sanitize(text) { return text ? text.replace(/[^\x00-\x7F]/g, '') : '' },
+    sanitize(text) {
+      if (!text) return ''
+      const source = typeof text.normalize === 'function' ? text.normalize('NFKC') : text
+      const invis = /\p{C}/u
+      const whitespace = /\s/u
+      let result = ''
+      for (const ch of Array.from(source)) {
+        if (whitespace.test(ch)) continue
+        if (invis.test(ch)) continue
+        result += ch
+      }
+      return result
+    },
     async ensureProcessCache(force = false) {
       if (this.processCacheLoaded && !force) return
       try {
@@ -399,12 +413,12 @@ export default {
         this.processCache = map; this.processCacheLoaded = true
       } catch (e) { console.error('加载工序缓存失败', e) }
     },
-    async updateProcess(r, cacheReady = false) {
+    async updateProcess(r, cacheReady = false, allowFetch = true, fetchBarcodeImage = true) {
       if (!cacheReady) await this.ensureProcessCache()
       const rawName = r.processName || ''; const name = rawName.trim()
-      if (!name) { r.processCode = ''; r.codeMissing = true; await this.updateBarcode(r); return }
+      if (!name) { r.processCode = ''; r.codeMissing = true; await this.updateBarcode(r, fetchBarcodeImage); return }
       let code = this.processCache[name]
-      if (!code) {
+      if (!code && allowFetch) {
         try {
           const res = await axios.get(`/api/processcodes/name/${encodeURIComponent(name)}`)
           if (res.data && res.data.code) {
@@ -414,7 +428,7 @@ export default {
         } catch (e) { /* ignore */ }
       }
       if (code) { r.processCode = code; r.codeMissing = false } else { r.processCode = rawName; r.codeMissing = true }
-      await this.updateBarcode(r)
+      await this.updateBarcode(r, fetchBarcodeImage)
     },
     async checkHours(r) { r.hoursMissing = r.hours == null || r.hours === '' },
     deleteRow(index) {
@@ -464,6 +478,9 @@ export default {
       const missing = []
       for (const entry of page.entries) {
         const code = this.sanitize(entry.record.barcode)
+        if (code !== entry.record.barcode) {
+          this.$set(entry.record, 'barcode', code)
+        }
         if (!code) continue
         if (this.barcodeCache[code]) {
           if (entry.record.barcodeImage !== this.barcodeCache[code]) {
@@ -494,18 +511,38 @@ export default {
     },
     async refreshProcesses() {
       await this.ensureProcessCache()
-      for (const r of this.preview) { // 串行
-        // eslint-disable-next-line no-await-in-loop
-        await this.updateProcess(r, true)
+      const missing = new Set()
+      for (const record of this.preview) {
+        const name = (record.processName || '').trim()
+        if (!name) continue
+        if (!this.processCache[name]) missing.add(name)
       }
+      if (missing.size) {
+        try {
+          const res = await axios.post('/api/processcodes/lookup', Array.from(missing))
+          const data = res && res.data ? res.data : {}
+          Object.keys(data || {}).forEach(key => {
+            if (!key) return
+            const value = data[key]
+            if (value == null) return
+            const code = String(value).trim()
+            if (code) this.$set(this.processCache, key, code)
+          })
+        } catch (error) {
+          console.error('批量加载工序失败', error)
+        }
+      }
+      const tasks = this.preview.map(r => this.updateProcess(r, true, false, false))
+      await Promise.all(tasks)
     },
-    async updateBarcode(r) {
+    async updateBarcode(r, fetchImage = true) {
       if (r.drawingNumber && r.notificationNumber && r.processCode) {
         const bar = `${r.drawingNumber}-${r.notificationNumber}-${r.processCode}`
         const clean = this.sanitize(bar)
         r.barcode = clean
         if (!clean) { r.barcodeImage = ''; return }
         if (this.barcodeCache[clean]) { r.barcodeImage = this.barcodeCache[clean]; return }
+        if (!fetchImage) { r.barcodeImage = ''; return }
         try {
           const res = await axios.get('/api/workrecords/generateBarcode', { params: { text: bar } })
           if (res && res.data) { this.$set(this.barcodeCache, clean, res.data); r.barcodeImage = res.data }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -39,95 +39,104 @@
       </div>
 
       <!-- 保持不变：force-new-page 确保新图号必换页 -->
-      <template v-for="(page, pageIndex) in pages" :key="pageIndex">
+      <template v-for="item in visiblePages" :key="item.index">
         <div
-          v-if="shouldRenderPage(pageIndex)"
           class="preview-page"
-          :class="{ 'active-page': pageIndex === currentPage, 'force-new-page': page.isFirstOfDrawing && pageIndex !== 0 }"
+          :class="{ 'active-page': item.index === currentPage, 'force-new-page': item.page.isFirstOfDrawing && item.index !== 0 }"
         >
-        <div class="d-flex justify-content-between align-items-center mb-2 page-heading">
-          <h3 class="h6 mb-0">图号：{{ page.drawingNumber || '（空）' }}</h3>
-          <span class="text-muted">第 {{ pageIndex + 1 }} 页 / 共 {{ pages.length }} 页</span>
-        </div>
+          <div class="d-flex justify-content-between align-items-center mb-2 page-heading">
+            <h3 class="h6 mb-0">图号：{{ item.page.drawingNumber || '（空）' }}</h3>
+            <span class="text-muted">第 {{ item.index + 1 }} 页 / 共 {{ pages.length }} 页</span>
+          </div>
 
-        <table class="table table-bordered table-sm table-striped mb-0">
-          <thead>
-            <tr>
-              <th class="notification-col">通知单号</th>
-              <th class="no-print">产品名称</th>
-              <th class="drawing-col">图号</th>
-              <th class="print-only plan-col">计划数</th>
-              <th class="no-print">名称</th>
-              <th class="plan-col no-print">计划数</th>
-              <th class="hours-col">单件工时</th>
-              <th class="no-print">工序代码</th>
-              <th class="process-col">工序</th>
-              <th class="print-only worker-code-col">人员代码</th>
-              <th class="print-only qualified-col">合格件数</th>
-              <th class="print-only time-col">起始时间</th>
-              <th class="print-only time-col">结束时间</th>
-              <th class="print-only inspector-col">检验员</th>
-              <th class="barcode-cell">条形码</th>
-              <th class="no-print"></th>
-            </tr>
-          </thead>
+          <table class="table table-bordered table-sm table-striped mb-0">
+            <thead>
+              <tr>
+                <th class="notification-col">通知单号</th>
+                <th class="no-print">产品名称</th>
+                <th class="drawing-col">图号</th>
+                <th class="print-only plan-col">计划数</th>
+                <th class="no-print">名称</th>
+                <th class="plan-col no-print">计划数</th>
+                <th class="hours-col">单件工时</th>
+                <th class="no-print">工序代码</th>
+                <th class="process-col">工序</th>
+                <th class="print-only worker-code-col">人员代码</th>
+                <th class="print-only qualified-col">合格件数</th>
+                <th class="print-only time-col">起始时间</th>
+                <th class="print-only time-col">结束时间</th>
+                <th class="print-only inspector-col">检验员</th>
+                <th class="barcode-cell">条形码</th>
+                <th class="no-print"></th>
+              </tr>
+            </thead>
 
-          <tbody>
-            <tr v-for="entry in page.entries" :key="entry.index" :class="{'table-danger': entry.record.codeMissing || entry.record.hoursMissing}">
-              <td class="notification-col">{{ entry.record.notificationNumber }}</td>
-              <td class="no-print">{{ entry.record.productName }}</td>
-              <td class="drawing-col">{{ entry.record.drawingNumber }}</td>
-              <td class="print-only plan-col">{{ entry.record.planQty }}</td>
-              <td class="no-print">{{ entry.record.partName }}</td>
-              <td class="plan-col no-print">
-                <input type="number" class="form-control form-control-sm" v-model.number="entry.record.planQty" />
-                <span class="print-text">{{ entry.record.planQty }}</span>
-              </td>
-              <td class="hours-col">
-                <input type="number" class="form-control form-control-sm no-print" style="width:80px" v-model.number="entry.record.hours" @blur="checkHours(entry.record)" />
-                <span class="print-text">{{ entry.record.hours }}</span>
-              </td>
-              <td class="no-print">{{ entry.record.processCode }}</td>
-              <td class="process-col">
-                <input class="form-control form-control-sm no-print" v-model="entry.record.processName" @blur="updateProcess(entry.record)" />
-                <span class="print-text">{{ entry.record.processName }}</span>
-              </td>
-              <td class="print-only worker-code-col"></td>
-              <td class="print-only qualified-col"></td>
-              <td class="print-only time-col"></td>
-              <td class="print-only time-col"></td>
-              <td class="print-only inspector-col"></td>
-              <td class="barcode-cell">
-                <div>{{ entry.record.barcode }}</div>
-                <img v-if="entry.record.barcodeImage" :src="'data:image/png;base64,'+entry.record.barcodeImage" />
-              </td>
-              <td class="no-print">
-                <button class="btn btn-sm btn-outline-primary me-1" @click="addRow(entry.index)">新增</button>
-                <button class="btn btn-sm btn-outline-danger" @click="deleteRow(entry.index)">删除</button>
-              </td>
-            </tr>
+            <tbody>
+              <tr v-for="entry in item.page.entries" :key="entry.index" :class="{'table-danger': entry.record.codeMissing || entry.record.hoursMissing}">
+                <td class="notification-col">{{ entry.record.notificationNumber }}</td>
+                <td class="no-print">{{ entry.record.productName }}</td>
+                <td class="drawing-col">{{ entry.record.drawingNumber }}</td>
+                <td class="print-only plan-col">{{ entry.record.planQty }}</td>
+                <td class="no-print">{{ entry.record.partName }}</td>
+                <td class="plan-col no-print">
+                  <input type="number" class="form-control form-control-sm" v-model.number="entry.record.planQty" />
+                  <span class="print-text">{{ entry.record.planQty }}</span>
+                </td>
+                <td class="hours-col">
+                  <input
+                    type="number"
+                    class="form-control form-control-sm no-print"
+                    style="width:80px"
+                    v-model.number="entry.record.hours"
+                    @blur="checkHours(entry.record)"
+                  />
+                  <span class="print-text">{{ entry.record.hours }}</span>
+                </td>
+                <td class="no-print">{{ entry.record.processCode }}</td>
+                <td class="process-col">
+                  <input
+                    class="form-control form-control-sm no-print"
+                    v-model="entry.record.processName"
+                    @blur="updateProcess(entry.record)"
+                  />
+                  <span class="print-text">{{ entry.record.processName }}</span>
+                </td>
+                <td class="print-only worker-code-col"></td>
+                <td class="print-only qualified-col"></td>
+                <td class="print-only time-col"></td>
+                <td class="print-only time-col"></td>
+                <td class="print-only inspector-col"></td>
+                <td class="barcode-cell">
+                  <div>{{ entry.record.barcode }}</div>
+                  <img v-if="entry.record.barcodeImage" :src="'data:image/png;base64,'+entry.record.barcodeImage" />
+                </td>
+                <td class="no-print">
+                  <button class="btn btn-sm btn-outline-primary me-1" @click="addRow(entry.index)">新增</button>
+                  <button class="btn btn-sm btn-outline-danger" @click="deleteRow(entry.index)">删除</button>
+                </td>
+              </tr>
 
-            <!-- 仍然渲染补白行，但屏幕隐藏、打印显示（见 style.css） -->
-            <tr v-for="n in page.blankCount" :key="'blank-'+pageIndex+'-'+n" class="blank-row">
-              <td class="notification-col">&nbsp;</td>
-              <td class="no-print">&nbsp;</td>
-              <td class="drawing-col">&nbsp;</td>
-              <td class="print-only plan-col">&nbsp;</td>
-              <td class="no-print">&nbsp;</td>
-              <td class="plan-col no-print">&nbsp;</td>
-              <td class="hours-col">&nbsp;</td>
-              <td class="no-print">&nbsp;</td>
-              <td class="process-col">&nbsp;</td>
-              <td class="print-only worker-code-col">&nbsp;</td>
-              <td class="print-only qualified-col">&nbsp;</td>
-              <td class="print-only time-col">&nbsp;</td>
-              <td class="print-only time-col">&nbsp;</td>
-              <td class="print-only inspector-col">&nbsp;</td>
-              <td class="barcode-cell"><div>&nbsp;</div></td>
-              <td class="no-print"></td>
-            </tr>
-          </tbody>
-        </table>
+              <!-- 仍然渲染补白行，但屏幕隐藏、打印显示（见 style.css） -->
+              <tr v-for="n in item.page.blankCount" :key="'blank-'+item.index+'-'+n" class="blank-row">
+                <td class="notification-col">&nbsp;</td>
+                <td class="no-print">&nbsp;</td>
+                <td class="drawing-col">&nbsp;</td>
+                <td class="print-only plan-col">&nbsp;</td>
+                <td class="no-print">&nbsp;</td>
+                <td class="plan-col no-print">&nbsp;</td>
+                <td class="hours-col">&nbsp;</td>
+                <td class="no-print">&nbsp;</td>
+                <td class="process-col">&nbsp;</td>
+                <td class="print-only worker-code-col">&nbsp;</td>
+                <td class="print-only qualified-col">&nbsp;</td>
+                <td class="print-only time-col">&nbsp;</td>
+                <td class="print-only time-col">&nbsp;</td>
+                <td class="print-only inspector-col">&nbsp;</td>
+                <td class="barcode-cell"><div>&nbsp;</div></td>
+                <td class="no-print"></td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </template>
     </div>
@@ -213,7 +222,27 @@ export default {
       })
       return pages
     },
-    currentPageInfo() { return this.pages[this.currentPage] || null }
+    currentPageInfo() { return this.pages[this.currentPage] || null },
+    visiblePages() {
+      if (!this.pages.length) return []
+      if (this.renderAllPages) {
+        return this.pages.map((page, index) => ({ page, index }))
+      }
+      const indices = new Set()
+      indices.add(this.currentPage)
+      if (this.renderBuffer > 0) {
+        for (let offset = 1; offset <= this.renderBuffer; offset += 1) {
+          const prev = this.currentPage - offset
+          const next = this.currentPage + offset
+          if (prev >= 0) indices.add(prev)
+          if (next < this.pages.length) indices.add(next)
+        }
+      }
+      return Array.from(indices)
+        .filter(index => index >= 0 && index < this.pages.length)
+        .sort((a, b) => a - b)
+        .map(index => ({ page: this.pages[index], index }))
+    }
   },
   watch: {
     currentPage(val) {
@@ -631,13 +660,6 @@ export default {
       if (!this.pages.length) { this.currentPage = 0; return }
       if (this.currentPage >= this.pages.length) this.currentPage = this.pages.length - 1
       if (this.currentPage < 0) this.currentPage = 0
-    },
-    shouldRenderPage(index) {
-      if (this.renderAllPages) return true
-      if (this.renderBuffer > 0) {
-        return Math.abs(index - this.currentPage) <= this.renderBuffer
-      }
-      return index === this.currentPage
     },
     preloadAdjacentBarcodes() {
       if (!this.pages.length) return

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -154,12 +154,18 @@ export default {
       showProgress: false,
       parseProgress: 0,
       renderAllPages: false,
-      renderBuffer: 1
+      renderBuffer: 0
     }
   },
   created() {
     this.fetchFiles()
     this.ensureProcessCache()
+  },
+  mounted() {
+    window.addEventListener('afterprint', this.handleAfterPrint)
+  },
+  beforeDestroy() {
+    window.removeEventListener('afterprint', this.handleAfterPrint)
   },
   computed: {
     currentFileName() {
@@ -210,7 +216,12 @@ export default {
     currentPageInfo() { return this.pages[this.currentPage] || null }
   },
   watch: {
-    currentPage(val) { this.$nextTick(() => this.loadBarcodesForPage(val)) }
+    currentPage(val) {
+      this.$nextTick(() => {
+        this.loadBarcodesForPage(val)
+        this.preloadAdjacentBarcodes()
+      })
+    }
   },
   methods: {
     handleRequestError(error, fallback) {
@@ -265,7 +276,11 @@ export default {
         this.fileId = this.selectedFileId
         this.file = null
         this.currentPage = 0
-        this.$nextTick(() => { this.ensurePageInRange(); this.loadBarcodesForPage(this.currentPage) })
+        this.$nextTick(() => {
+          this.ensurePageInRange()
+          this.loadBarcodesForPage(this.currentPage)
+          this.preloadAdjacentBarcodes()
+        })
       } catch (e) { console.error(e); alert('加载失败') }
       this.loading = false
     },
@@ -330,7 +345,11 @@ export default {
         if (warn.length) alert(`发现${warn.length}条记录缺少单件工时或工序码，请检查`)
         await this.fetchFiles()
         this.currentPage = 0
-        this.$nextTick(() => { this.ensurePageInRange(); this.loadBarcodesForPage(this.currentPage) })
+        this.$nextTick(() => {
+          this.ensurePageInRange()
+          this.loadBarcodesForPage(this.currentPage)
+          this.preloadAdjacentBarcodes()
+        })
       } catch (e) {
         this.handleRequestError(e, '解析失败')
         this.showProgress = false
@@ -387,6 +406,9 @@ export default {
         this.renderAllPages = false
         document.title = title
       }
+    },
+    handleAfterPrint() {
+      this.renderAllPages = false
     },
     sanitize(text) {
       if (!text) return ''
@@ -612,7 +634,19 @@ export default {
     },
     shouldRenderPage(index) {
       if (this.renderAllPages) return true
-      return Math.abs(index - this.currentPage) <= this.renderBuffer
+      if (this.renderBuffer > 0) {
+        return Math.abs(index - this.currentPage) <= this.renderBuffer
+      }
+      return index === this.currentPage
+    },
+    preloadAdjacentBarcodes() {
+      if (!this.pages.length) return
+      const neighbors = []
+      if (this.currentPage > 0) neighbors.push(this.currentPage - 1)
+      if (this.currentPage < this.pages.length - 1) neighbors.push(this.currentPage + 1)
+      neighbors.forEach(pageIndex => {
+        this.loadBarcodesForPage(pageIndex)
+      })
     }
   }
 }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -521,12 +521,17 @@ export default {
       } finally { this.loading = false }
       const title = document.title
       if (this.currentFileName) document.title = this.currentFileName
+      const originalBuffer = this.renderBuffer
       this.renderAllPages = true
+      this.renderBuffer = Math.max(originalBuffer, 2)
       try {
         await this.$nextTick()
+        await this.$nextTick()
+        await new Promise(resolve => requestAnimationFrame(() => resolve()))
         window.print()
       } finally {
         this.renderAllPages = false
+        this.renderBuffer = originalBuffer
         document.title = title
       }
     },

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -486,6 +486,14 @@ export default {
           }
         }
       }
+      if (!message && response && response.status === 409) {
+        const url = response.config && response.config.url ? String(response.config.url) : ''
+        if (url.includes('/api/processcodes')) {
+          message = '工序代码已存在，请使用其他代号'
+        } else {
+          message = '请求与服务器当前状态冲突，请检查数据后重试'
+        }
+      }
       if (!message && error && typeof error.message === 'string') {
         message = error.message
       }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -22,128 +22,147 @@
       </div>
     </div>
 
-    <div v-if="preview.length" id="preview-table">
-      <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mb-2 no-print">
-        <h2 class="h5 mb-0">预览</h2>
-        <div class="d-flex flex-wrap align-items-center gap-2">
-          <div>当前图号：{{ currentPageInfo?.drawingNumber || '—' }}（第 {{ currentPage + 1 }} / {{ pages.length }} 页）</div>
-          <div class="input-group input-group-sm" style="width: 220px;">
-            <input class="form-control" placeholder="搜索图号" v-model.trim="drawingSearch" @keyup.enter="jumpToDrawing">
-            <button class="btn btn-outline-secondary" @click="jumpToDrawing">跳转</button>
-          </div>
-          <div class="btn-group btn-group-sm">
-            <button class="btn btn-outline-secondary" @click="prevPage" :disabled="currentPage === 0">上一页</button>
-            <button class="btn btn-outline-secondary" @click="nextPage" :disabled="currentPage >= pages.length - 1">下一页</button>
+    <div v-if="preview.length" id="preview-table" class="upload-preview-layout">
+      <RecordIssuePanel
+        class="no-print issue-panel-container"
+        :groups="issueGroups"
+        :active-group="issueFilter"
+        @select="selectIssueGroup"
+        @clear="clearIssueFilter"
+        @bulk="handleBulkFill"
+      />
+      <div class="preview-main">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mb-2 no-print">
+          <h2 class="h5 mb-0">预览</h2>
+          <div class="d-flex flex-wrap align-items-center gap-2">
+            <div>当前图号：{{ currentPageInfo?.drawingNumber || '—' }}（第 {{ currentPage + 1 }} / {{ pages.length }} 页）</div>
+            <div class="input-group input-group-sm" style="width: 220px;">
+              <input class="form-control" placeholder="搜索图号" v-model.trim="drawingSearch" @keyup.enter="jumpToDrawing">
+              <button class="btn btn-outline-secondary" @click="jumpToDrawing">跳转</button>
+            </div>
+            <div class="btn-group btn-group-sm">
+              <button class="btn btn-outline-secondary" @click="prevPage" :disabled="currentPage === 0">上一页</button>
+              <button class="btn btn-outline-secondary" @click="nextPage" :disabled="currentPage >= pages.length - 1">下一页</button>
+            </div>
           </div>
         </div>
+
+        <div v-if="issueFilter" class="alert alert-warning py-2 px-3 mb-3 no-print issue-filter-alert">
+          <div>
+            正在处理图号「{{ issueFilter.drawingNumber || '（空图号）' }}」缺少「{{ issueFilter.type }}」的 {{ issueFilter.indexes.length }} 条记录。
+          </div>
+          <button type="button" class="btn btn-sm btn-outline-secondary" @click="clearIssueFilter">退出筛选</button>
+        </div>
+
+        <!-- 保持不变：force-new-page 确保新图号必换页 -->
+        <template v-for="item in visiblePages" :key="item.index">
+          <div
+            class="preview-page"
+            :class="{ 'active-page': item.index === currentPage, 'force-new-page': item.page.isFirstOfDrawing && item.index !== 0 }"
+          >
+            <div class="d-flex justify-content-between align-items-center mb-2 page-heading">
+              <h3 class="h6 mb-0">图号：{{ item.page.drawingNumber || '（空）' }}</h3>
+              <span class="text-muted">第 {{ item.index + 1 }} 页 / 共 {{ pages.length }} 页</span>
+            </div>
+
+            <table class="table table-bordered table-sm table-striped mb-0">
+              <thead>
+                <tr>
+                  <th class="notification-col">通知单号</th>
+                  <th class="no-print">产品名称</th>
+                  <th class="drawing-col">图号</th>
+                  <th class="print-only plan-col">计划数</th>
+                  <th class="no-print">名称</th>
+                  <th class="plan-col no-print">计划数</th>
+                  <th class="hours-col">单件工时</th>
+                  <th class="no-print">工序代码</th>
+                  <th class="process-col">工序</th>
+                  <th class="print-only worker-code-col">人员代码</th>
+                  <th class="print-only qualified-col">合格件数</th>
+                  <th class="print-only time-col">起始时间</th>
+                  <th class="print-only time-col">结束时间</th>
+                  <th class="print-only inspector-col">检验员</th>
+                  <th class="barcode-cell">条形码</th>
+                  <th class="no-print"></th>
+                </tr>
+              </thead>
+
+              <tbody>
+                <tr
+                  v-for="entry in item.page.entries"
+                  :key="entry.index"
+                  :class="{ 'table-danger': entry.record.hasIssue }"
+                  :title="entry.record.issueSummary || ''"
+                >
+                  <td :class="['notification-col', { 'missing-cell': entry.record.notificationMissing }]"><span>{{ entry.record.notificationNumber }}</span></td>
+                  <td :class="['no-print', { 'missing-cell': entry.record.productMissing }]">{{ entry.record.productName }}</td>
+                  <td :class="['drawing-col', { 'missing-cell': entry.record.drawingMissing }]">{{ entry.record.drawingNumber }}</td>
+                  <td class="print-only plan-col">{{ entry.record.planQty }}</td>
+                  <td :class="['no-print', { 'missing-cell': entry.record.partMissing }]">{{ entry.record.partName }}</td>
+                  <td :class="['plan-col', 'no-print', { 'missing-cell': entry.record.planMissing }]">
+                    <input
+                      type="number"
+                      class="form-control form-control-sm"
+                      :class="{ 'is-invalid': entry.record.planMissing }"
+                      v-model.number="entry.record.planQty"
+                      @input="handlePlanInput(entry.record)"
+                      @blur="handlePlanInput(entry.record)"
+                    />
+                    <span class="print-text">{{ entry.record.planQty }}</span>
+                  </td>
+                  <td :class="['hours-col', { 'missing-cell': entry.record.hoursMissing }]">
+                    <input
+                      type="number"
+                      class="form-control form-control-sm no-print"
+                      style="width:80px"
+                      v-model.number="entry.record.hours"
+                      :class="{ 'is-invalid': entry.record.hoursMissing }"
+                      @input="checkHours(entry.record)"
+                      @blur="checkHours(entry.record)"
+                    />
+                    <span class="print-text">{{ entry.record.hours }}</span>
+                  </td>
+                  <td :class="['no-print', { 'missing-cell': entry.record.codeMissing }]">{{ entry.record.processCode }}</td>
+                  <td :class="['process-col', { 'missing-cell': entry.record.processMissing || entry.record.codeMissing }]">
+                    <input
+                      class="form-control form-control-sm no-print"
+                      v-model="entry.record.processName"
+                      @blur="updateProcess(entry.record)"
+                      @input="handleProcessInput(entry.record)"
+                      :class="{ 'is-invalid': entry.record.processMissing || entry.record.codeMissing }"
+                    />
+                    <span class="print-text">{{ entry.record.processName }}</span>
+                  </td>
+                  <td class="print-only worker-code-col"></td>
+                  <td class="print-only qualified-col"></td>
+                  <td class="print-only time-col"></td>
+                  <td class="print-only time-col"></td>
+                  <td class="print-only inspector-col"></td>
+                  <td :class="['barcode-cell', { 'missing-cell': entry.record.barcodeMissing }]">
+                    <div>{{ entry.record.barcode }}</div>
+                    <img v-if="entry.record.barcodeImage" :src="'data:image/png;base64,'+entry.record.barcodeImage" />
+                  </td>
+                  <td class="no-print">
+                    <div v-if="entry.record.issueSummary" class="issue-tag mb-1">⚠️ {{ entry.record.issueSummary }}</div>
+                    <button class="btn btn-sm btn-outline-primary me-1" @click="addRow(entry.index)">新增</button>
+                    <button class="btn btn-sm btn-outline-danger" @click="deleteRow(entry.index)">删除</button>
+                  </td>
+                </tr>
+
+              </tbody>
+            </table>
+          </div>
+        </template>
       </div>
-
-      <!-- 保持不变：force-new-page 确保新图号必换页 -->
-      <template v-for="item in visiblePages" :key="item.index">
-        <div
-          class="preview-page"
-          :class="{ 'active-page': item.index === currentPage, 'force-new-page': item.page.isFirstOfDrawing && item.index !== 0 }"
-        >
-          <div class="d-flex justify-content-between align-items-center mb-2 page-heading">
-            <h3 class="h6 mb-0">图号：{{ item.page.drawingNumber || '（空）' }}</h3>
-            <span class="text-muted">第 {{ item.index + 1 }} 页 / 共 {{ pages.length }} 页</span>
-          </div>
-
-          <table class="table table-bordered table-sm table-striped mb-0">
-            <thead>
-              <tr>
-                <th class="notification-col">通知单号</th>
-                <th class="no-print">产品名称</th>
-                <th class="drawing-col">图号</th>
-                <th class="print-only plan-col">计划数</th>
-                <th class="no-print">名称</th>
-                <th class="plan-col no-print">计划数</th>
-                <th class="hours-col">单件工时</th>
-                <th class="no-print">工序代码</th>
-                <th class="process-col">工序</th>
-                <th class="print-only worker-code-col">人员代码</th>
-                <th class="print-only qualified-col">合格件数</th>
-                <th class="print-only time-col">起始时间</th>
-                <th class="print-only time-col">结束时间</th>
-                <th class="print-only inspector-col">检验员</th>
-                <th class="barcode-cell">条形码</th>
-                <th class="no-print"></th>
-              </tr>
-            </thead>
-
-            <tbody>
-              <tr
-                v-for="entry in item.page.entries"
-                :key="entry.index"
-                :class="{ 'table-danger': entry.record.hasIssue }"
-                :title="entry.record.issueSummary || ''"
-              >
-                <td :class="['notification-col', { 'missing-cell': entry.record.notificationMissing }]"><span>{{ entry.record.notificationNumber }}</span></td>
-                <td :class="['no-print', { 'missing-cell': entry.record.productMissing }]">{{ entry.record.productName }}</td>
-                <td :class="['drawing-col', { 'missing-cell': entry.record.drawingMissing }]">{{ entry.record.drawingNumber }}</td>
-                <td class="print-only plan-col">{{ entry.record.planQty }}</td>
-                <td :class="['no-print', { 'missing-cell': entry.record.partMissing }]">{{ entry.record.partName }}</td>
-                <td :class="['plan-col', 'no-print', { 'missing-cell': entry.record.planMissing }]">
-                  <input
-                    type="number"
-                    class="form-control form-control-sm"
-                    :class="{ 'is-invalid': entry.record.planMissing }"
-                    v-model.number="entry.record.planQty"
-                    @input="handlePlanInput(entry.record)"
-                    @blur="handlePlanInput(entry.record)"
-                  />
-                  <span class="print-text">{{ entry.record.planQty }}</span>
-                </td>
-                <td :class="['hours-col', { 'missing-cell': entry.record.hoursMissing }]">
-                  <input
-                    type="number"
-                    class="form-control form-control-sm no-print"
-                    style="width:80px"
-                    v-model.number="entry.record.hours"
-                    :class="{ 'is-invalid': entry.record.hoursMissing }"
-                    @input="checkHours(entry.record)"
-                    @blur="checkHours(entry.record)"
-                  />
-                  <span class="print-text">{{ entry.record.hours }}</span>
-                </td>
-                <td :class="['no-print', { 'missing-cell': entry.record.codeMissing }]">{{ entry.record.processCode }}</td>
-                <td :class="['process-col', { 'missing-cell': entry.record.processMissing || entry.record.codeMissing }]">
-                  <input
-                    class="form-control form-control-sm no-print"
-                    v-model="entry.record.processName"
-                    @blur="updateProcess(entry.record)"
-                    @input="handleProcessInput(entry.record)"
-                    :class="{ 'is-invalid': entry.record.processMissing || entry.record.codeMissing }"
-                  />
-                  <span class="print-text">{{ entry.record.processName }}</span>
-                </td>
-                <td class="print-only worker-code-col"></td>
-                <td class="print-only qualified-col"></td>
-                <td class="print-only time-col"></td>
-                <td class="print-only time-col"></td>
-                <td class="print-only inspector-col"></td>
-                <td :class="['barcode-cell', { 'missing-cell': entry.record.barcodeMissing }]">
-                  <div>{{ entry.record.barcode }}</div>
-                  <img v-if="entry.record.barcodeImage" :src="'data:image/png;base64,'+entry.record.barcodeImage" />
-                </td>
-                <td class="no-print">
-                  <div v-if="entry.record.issueSummary" class="issue-tag mb-1">⚠️ {{ entry.record.issueSummary }}</div>
-                  <button class="btn btn-sm btn-outline-primary me-1" @click="addRow(entry.index)">新增</button>
-                  <button class="btn btn-sm btn-outline-danger" @click="deleteRow(entry.index)">删除</button>
-                </td>
-              </tr>
-
-            </tbody>
-          </table>
-        </div>
-      </template>
     </div>
   </section>
 </template>
 
 <script>
 import axios from 'axios'
+import RecordIssuePanel from './RecordIssuePanel.vue'
 export default {
+  components: { RecordIssuePanel },
   data() {
     return {
       file: null,
@@ -161,7 +180,9 @@ export default {
       showProgress: false,
       parseProgress: 0,
       renderAllPages: false,
-      renderBuffer: 0
+      renderBuffer: 0,
+      issueFilter: null,
+      issueCompletionNotified: false
     }
   },
   created() {
@@ -181,9 +202,8 @@ export default {
       const f = this.files.find(x => x.id === id)
       return f ? f.fileName : ''
     },
-    pages() {
+    allPages() {
       if (!this.preview.length) return []
-      // 按图号分段
       const grouped = []
       let current = null
       this.preview.forEach((record, index) => {
@@ -194,7 +214,6 @@ export default {
         }
         current.entries.push({ record, index })
       })
-      // 按 rowsPerPage 分页，标记每个图号的第一页
       const pages = []
       const size = this.rowsPerPage
       grouped.forEach(group => {
@@ -217,6 +236,26 @@ export default {
       })
       return pages
     },
+    pages() {
+      const base = this.allPages
+      if (!this.issueFilter) return base
+      const filterSet = new Set(this.issueFilter.indexes)
+      const filtered = []
+      let lastDrawing = null
+      base.forEach(page => {
+        const entries = page.entries.filter(entry => filterSet.has(entry.index))
+        if (!entries.length) return
+        const drawing = page.drawingNumber
+        const isFirst = drawing !== lastDrawing
+        filtered.push({
+          drawingNumber: drawing,
+          entries,
+          isFirstOfDrawing: isFirst
+        })
+        lastDrawing = drawing
+      })
+      return filtered
+    },
     currentPageInfo() { return this.pages[this.currentPage] || null },
     visiblePages() {
       if (!this.pages.length) return []
@@ -237,14 +276,74 @@ export default {
         .filter(index => index >= 0 && index < this.pages.length)
         .sort((a, b) => a - b)
         .map(index => ({ page: this.pages[index], index }))
+    },
+    issueGroups() {
+      if (!this.preview.length) return []
+      const groups = new Map()
+      this.preview.forEach((record, index) => {
+        if (!record || !Array.isArray(record.issueTypes) || !record.issueTypes.length) return
+        const drawing = record.drawingNumber || ''
+        record.issueTypes.forEach(type => {
+          const key = `${drawing}|||${type}`
+          if (!groups.has(key)) {
+            groups.set(key, {
+              key,
+              drawingNumber: drawing,
+              type,
+              count: 0,
+              indexes: []
+            })
+          }
+          const group = groups.get(key)
+          group.count += 1
+          group.indexes.push(index)
+        })
+      })
+      return Array.from(groups.values()).sort((a, b) => {
+        if (b.count !== a.count) return b.count - a.count
+        const aDrawing = a.drawingNumber || ''
+        const bDrawing = b.drawingNumber || ''
+        if (aDrawing !== bDrawing) return aDrawing.localeCompare(bDrawing, 'zh-Hans')
+        return a.type.localeCompare(b.type, 'zh-Hans')
+      })
     }
   },
   watch: {
+    pages(newPages) {
+      if (!newPages.length) {
+        this.currentPage = 0
+        return
+      }
+      if (this.currentPage >= newPages.length) {
+        this.currentPage = newPages.length - 1
+      }
+    },
     currentPage(val) {
       this.$nextTick(() => {
         this.loadBarcodesForPage(val)
         this.preloadAdjacentBarcodes()
       })
+    },
+    issueGroups: {
+      handler(newGroups) {
+        if (!this.issueFilter) {
+          if (newGroups.length) this.issueCompletionNotified = false
+          return
+        }
+        const currentKey = this.issueFilter.key
+        const match = newGroups.find(group => group.key === currentKey)
+        if (match) {
+          this.issueFilter.indexes = match.indexes.slice()
+          if (!match.count) {
+            this.advanceToNextIssueGroup(newGroups)
+          } else {
+            this.$nextTick(() => this.ensureCurrentPageContainsFilter())
+          }
+        } else {
+          this.advanceToNextIssueGroup(newGroups)
+        }
+      },
+      deep: true
     }
   },
   methods: {
@@ -291,6 +390,7 @@ export default {
       record.barcodeMissing = record.barcodeMissing === true
       record.issueSummary = ''
       record.hasIssue = false
+      record.issueTypes = []
       this.updateIssueFlags(record)
       return record
     },
@@ -335,6 +435,10 @@ export default {
 
       record.hasIssue = issues.length > 0
       record.issueSummary = record.hasIssue ? `缺少：${issues.join('、')}` : ''
+      record.issueTypes = issues.slice()
+      if (record.hasIssue) {
+        this.issueCompletionNotified = false
+      }
     },
     handleRequestError(error, fallback) {
       if (error instanceof Error && error.message === 'missing-user') return
@@ -387,6 +491,8 @@ export default {
         this.fileId = this.selectedFileId
         this.file = null
         this.currentPage = 0
+        this.issueFilter = null
+        this.issueCompletionNotified = false
         this.$nextTick(() => {
           this.ensurePageInRange()
           this.loadBarcodesForPage(this.currentPage)
@@ -407,6 +513,7 @@ export default {
         this.selectedFileId = ''
         this.preview = []
         this.currentPage = 0
+        this.issueFilter = null
         await this.fetchFiles()
         alert('已删除')
       } catch (e) {
@@ -423,7 +530,7 @@ export default {
       let headers
       try { headers = this.requireUserHeaders() }
       catch (err) { return }
-      this.loading = true; this.showProgress = true; this.parseProgress = 5; this.barcodeCache = {}
+      this.loading = true; this.showProgress = true; this.parseProgress = 5; this.barcodeCache = {}; this.issueFilter = null; this.issueCompletionNotified = false
       try {
         const data = new FormData(); data.append('file', this.file); data.append('store', 'false')
         const res = await axios.post('/api/workrecords/parse', data, { headers })
@@ -489,6 +596,8 @@ export default {
         const hasSupp = responses.some(r => r && r.supplemental)
         this.preview = []
         this.file = null
+        this.issueFilter = null
+        this.issueCompletionNotified = false
         alert(hasSupp ? '保存成功，部分记录为补录，请核查。' : '保存成功')
         await this.fetchFiles()
         this.$emit('saved')
@@ -795,6 +904,178 @@ export default {
       if (this.currentPage < this.pages.length - 1) neighbors.push(this.currentPage + 1)
       neighbors.forEach(pageIndex => {
         this.loadBarcodesForPage(pageIndex)
+      })
+    },
+    selectIssueGroup(group) {
+      if (!group) {
+        this.clearIssueFilter()
+        return
+      }
+      this.issueFilter = {
+        key: group.key,
+        drawingNumber: group.drawingNumber,
+        type: group.type,
+        indexes: group.indexes.slice()
+      }
+      this.issueCompletionNotified = false
+      this.$nextTick(() => {
+        const filteredPages = this.pages
+        const targetIndex = this.issueFilter && this.issueFilter.indexes.length ? this.issueFilter.indexes[0] : null
+        let pageIndex = filteredPages.findIndex(page => page.entries.some(entry => entry.index === targetIndex))
+        if (pageIndex < 0) pageIndex = 0
+        if (filteredPages.length) {
+          if (pageIndex >= filteredPages.length) pageIndex = filteredPages.length - 1
+          this.currentPage = Math.max(0, pageIndex)
+        } else {
+          this.currentPage = 0
+        }
+      })
+    },
+    clearIssueFilter() {
+      this.issueFilter = null
+      this.issueCompletionNotified = false
+      this.currentPage = 0
+    },
+    advanceToNextIssueGroup(groups) {
+      const remaining = groups.filter(group => group.count > 0)
+      if (!remaining.length) {
+        const hadFilter = !!this.issueFilter
+        this.issueFilter = null
+        if (hadFilter && !this.issueCompletionNotified) {
+          alert('所有缺陷已处理完毕！')
+          this.issueCompletionNotified = true
+        }
+        return
+      }
+      this.issueCompletionNotified = false
+      const currentKey = this.issueFilter ? this.issueFilter.key : null
+      let next = remaining[0]
+      if (currentKey) {
+        const idx = remaining.findIndex(group => group.key === currentKey)
+        if (idx >= 0) {
+          next = remaining[(idx + 1) % remaining.length]
+        }
+      }
+      this.selectIssueGroup(next)
+    },
+    ensureCurrentPageContainsFilter() {
+      if (!this.issueFilter) return
+      const filteredPages = this.pages
+      if (!filteredPages.length) {
+        this.currentPage = 0
+        return
+      }
+      if (this.currentPage >= filteredPages.length) {
+        this.currentPage = filteredPages.length - 1
+      }
+      const activeIndexes = new Set(this.issueFilter.indexes)
+      const current = filteredPages[this.currentPage]
+      if (current && current.entries.some(entry => activeIndexes.has(entry.index))) {
+        return
+      }
+      const fallback = filteredPages.findIndex(page => page.entries.some(entry => activeIndexes.has(entry.index)))
+      if (fallback >= 0) {
+        this.currentPage = fallback
+      } else {
+        this.currentPage = 0
+      }
+    },
+    getBulkConfig(type) {
+      switch (type) {
+        case '工序代码':
+          return {
+            prompt: '请输入工序代码（将应用到当前筛选的所有记录）',
+            prepare(input) {
+              const value = String(input || '').trim()
+              if (!value) {
+                alert('请输入有效的工序代码')
+                return undefined
+              }
+              return value
+            },
+            apply(record, value) {
+              record.processCode = value
+              record.serverCodeMissing = false
+              record.codeMissing = false
+              return this.updateBarcode(record)
+            }
+          }
+        case '工序':
+          return {
+            prompt: '请输入工序名称（将应用到当前筛选的所有记录）',
+            prepare(input) {
+              const value = String(input || '').trim()
+              if (!value) {
+                alert('请输入有效的工序名称')
+                return undefined
+              }
+              return value
+            },
+            apply(record, value) {
+              record.processName = value
+              return this.updateProcess(record)
+            }
+          }
+        case '单件工时':
+          return {
+            prompt: '请输入单件工时（数字，将应用到当前筛选的所有记录）',
+            prepare(input) {
+              const value = Number(input)
+              if (Number.isNaN(value)) {
+                alert('请输入有效的数字')
+                return undefined
+              }
+              return value
+            },
+            apply(record, value) {
+              record.hours = value
+              record.hoursMissing = false
+              this.updateIssueFlags(record)
+            }
+          }
+        case '计划数':
+          return {
+            prompt: '请输入计划数（数字，将应用到当前筛选的所有记录）',
+            prepare(input) {
+              const value = Number(input)
+              if (Number.isNaN(value)) {
+                alert('请输入有效的数字')
+                return undefined
+              }
+              return value
+            },
+            apply(record, value) {
+              record.planQty = value
+              record.planMissing = false
+              this.updateIssueFlags(record)
+            }
+          }
+        default:
+          return null
+      }
+    },
+    handleBulkFill(group) {
+      if (!group) return
+      const config = this.getBulkConfig(group.type)
+      if (!config) {
+        alert('该缺陷暂不支持批量填写')
+        return
+      }
+      const input = prompt(config.prompt, '')
+      if (input === null) return
+      const prepared = config.prepare ? config.prepare.call(this, input) : input
+      if (prepared === undefined) return
+      const tasks = []
+      group.indexes.slice().forEach(idx => {
+        const record = this.preview[idx]
+        if (!record) return
+        const result = config.apply.call(this, record, prepared, idx)
+        if (result && typeof result.then === 'function') {
+          tasks.push(result)
+        }
+      })
+      Promise.all(tasks).finally(() => {
+        this.ensureCurrentPageContainsFilter()
       })
     }
   }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="section-card">
     <h2 class="h5">Excel上传</h2>
-    <div class="input-group mb-2">
+    <div class="input-group mb-2 no-print">
       <input class="form-control" type="file" @change="onFileChange">
       <button class="btn btn-outline-primary" @click="parse" :disabled="!file">解析</button>
       <select class="form-select" style="max-width:180px" v-model="selectedFileId">
@@ -16,7 +16,7 @@
       <div class="spinner-border ms-2" v-if="loading"></div>
     </div>
 
-    <div class="progress mb-2" v-if="showProgress" style="height: 0.75rem;">
+    <div class="progress mb-2 no-print" v-if="showProgress" style="height: 0.75rem;">
       <div class="progress-bar" role="progressbar" :style="{ width: parseProgress + '%' }">
         {{ parseProgress }}%
       </div>
@@ -62,11 +62,11 @@
               <th class="hours-col">单件工时</th>
               <th class="no-print">工序代码</th>
               <th class="process-col">工序</th>
-              <th class="print-only">人员代码</th>
-              <th class="print-only">合格件数</th>
-              <th class="print-only">起始时间</th>
-              <th class="print-only">结束时间</th>
-              <th class="print-only">检验员</th>
+              <th class="print-only worker-code-col">人员代码</th>
+              <th class="print-only qualified-col">合格件数</th>
+              <th class="print-only time-col">起始时间</th>
+              <th class="print-only time-col">结束时间</th>
+              <th class="print-only inspector-col">检验员</th>
               <th class="barcode-cell">条形码</th>
               <th class="no-print"></th>
             </tr>
@@ -92,11 +92,11 @@
                 <input class="form-control form-control-sm no-print" v-model="entry.record.processName" @blur="updateProcess(entry.record)" />
                 <span class="print-text">{{ entry.record.processName }}</span>
               </td>
-              <td class="print-only"></td>
-              <td class="print-only"></td>
-              <td class="print-only"></td>
-              <td class="print-only"></td>
-              <td class="print-only"></td>
+              <td class="print-only worker-code-col"></td>
+              <td class="print-only qualified-col"></td>
+              <td class="print-only time-col"></td>
+              <td class="print-only time-col"></td>
+              <td class="print-only inspector-col"></td>
               <td class="barcode-cell">
                 <div>{{ entry.record.barcode }}</div>
                 <img v-if="entry.record.barcodeImage" :src="'data:image/png;base64,'+entry.record.barcodeImage" />
@@ -118,11 +118,11 @@
               <td class="hours-col">&nbsp;</td>
               <td class="no-print">&nbsp;</td>
               <td class="process-col">&nbsp;</td>
-              <td class="print-only">&nbsp;</td>
-              <td class="print-only">&nbsp;</td>
-              <td class="print-only">&nbsp;</td>
-              <td class="print-only">&nbsp;</td>
-              <td class="print-only">&nbsp;</td>
+              <td class="print-only worker-code-col">&nbsp;</td>
+              <td class="print-only qualified-col">&nbsp;</td>
+              <td class="print-only time-col">&nbsp;</td>
+              <td class="print-only time-col">&nbsp;</td>
+              <td class="print-only inspector-col">&nbsp;</td>
               <td class="barcode-cell"><div>&nbsp;</div></td>
               <td class="no-print"></td>
             </tr>

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -106,7 +106,7 @@
                       :class="{ 'is-invalid': entry.record.planMissing }"
                       v-model.number="entry.record.planQty"
                       @input="handlePlanInput(entry.record)"
-                      @blur="handlePlanInput(entry.record)"
+                      @blur="handlePlanBlur(entry.record)"
                     />
                     <span class="print-text">{{ entry.record.planQty }}</span>
                   </td>
@@ -118,7 +118,7 @@
                       v-model.number="entry.record.hours"
                       :class="{ 'is-invalid': entry.record.hoursMissing }"
                       @input="checkHours(entry.record)"
-                      @blur="checkHours(entry.record)"
+                      @blur="handleHoursBlur(entry.record)"
                     />
                     <span class="print-text">{{ entry.record.hours }}</span>
                   </td>
@@ -137,7 +137,7 @@
                     <input
                       class="form-control form-control-sm no-print"
                       v-model="entry.record.processName"
-                      @blur="updateProcess(entry.record)"
+                      @blur="handleProcessBlur(entry.record)"
                       @input="handleProcessInput(entry.record)"
                       :class="{ 'is-invalid': entry.record.processMissing || entry.record.codeMissing }"
                     />
@@ -674,6 +674,92 @@ export default {
       }
       return result
     },
+    buildAutoSavePayload(record) {
+      if (!record) return null
+      const asText = (value) => {
+        if (value === null || value === undefined) return null
+        const str = String(value).trim()
+        return str.length ? str : null
+      }
+      const asInteger = (value) => {
+        if (value === null || value === undefined || value === '') return null
+        const num = Number(value)
+        if (Number.isNaN(num)) return null
+        return Math.trunc(num)
+      }
+      const asNumber = (value) => {
+        if (value === null || value === undefined || value === '') return null
+        const num = Number(value)
+        return Number.isNaN(num) ? null : num
+      }
+      const payload = {
+        id: record.id != null ? record.id : null,
+        notificationNumber: asText(record.notificationNumber),
+        productName: asText(record.productName),
+        drawingNumber: asText(record.drawingNumber),
+        productCode: asText(record.productCode),
+        partName: asText(record.partName),
+        planQty: asInteger(record.planQty),
+        sourceRowNumber: asInteger(record.sourceRowNumber),
+        processName: asText(record.processName),
+        processCode: asText(record.processCode),
+        barcode: asText(this.sanitize(record.barcode)),
+        barcodeImage: record.barcodeImage || null,
+        batchNumber: asText(record.batchNumber),
+        hours: asNumber(record.hours),
+        workerCodes: asText(record.workerCodes),
+        workerNames: asText(record.workerNames),
+        workerQtys: asText(record.workerQtys),
+        qualifiedQty: asNumber(record.qualifiedQty),
+        hourSubtotal: asNumber(record.hourSubtotal),
+        supplemental: record.supplemental,
+        filled: record.filled,
+        startTime: record.startTime || null,
+        endTime: record.endTime || null,
+        inspector: asText(record.inspector),
+        remark1: asText(record.remark1),
+        remark2: asText(record.remark2)
+      }
+      return payload
+    },
+    async autoSaveRecord(record) {
+      if (!record) return
+      if (!this.fileId) return
+      if (record._autoSaving) {
+        record._autoSavePending = true
+        return
+      }
+      let headers
+      try { headers = this.requireUserHeaders() }
+      catch (err) { return }
+      const payload = this.buildAutoSavePayload(record)
+      if (!payload) return
+      record._autoSaving = true
+      try {
+        const res = await axios.post('/api/workrecords/autosave', payload, {
+          headers,
+          params: { fileId: this.fileId }
+        })
+        if (res && res.data) {
+          const updated = this.decorateRecord({
+            ...res.data,
+            barcodeImage: res.data.barcodeImage || payload.barcodeImage
+          })
+          Object.keys(updated).forEach(key => {
+            if (key === '_autoSaving' || key === '_autoSavePending') return
+            this.$set(record, key, updated[key])
+          })
+        }
+      } catch (error) {
+        this.handleRequestError(error, '自动保存失败')
+      } finally {
+        record._autoSaving = false
+        if (record._autoSavePending) {
+          record._autoSavePending = false
+          this.autoSaveRecord(record)
+        }
+      }
+    },
     async rememberProcessCode(record) {
       if (!record) return
       const name = record.processName != null ? String(record.processName).trim() : ''
@@ -742,16 +828,33 @@ export default {
         record.barcode = ''
         record.barcodeImage = ''
         this.updateIssueFlags(record)
+        await this.autoSaveRecord(record)
         return
       }
       record.serverCodeMissing = false
       record.codeMissing = false
       await this.updateBarcode(record)
       await this.rememberProcessCode(record)
+      await this.autoSaveRecord(record)
     },
     handlePlanInput(record) {
       if (!record) return
       this.updateIssueFlags(record)
+    },
+    async handlePlanBlur(record) {
+      if (!record) return
+      this.handlePlanInput(record)
+      await this.autoSaveRecord(record)
+    },
+    async handleHoursBlur(record) {
+      if (!record) return
+      this.checkHours(record)
+      await this.autoSaveRecord(record)
+    },
+    async handleProcessBlur(record) {
+      if (!record) return
+      await this.updateProcess(record)
+      await this.autoSaveRecord(record)
     },
     async updateProcess(r, cacheReady = false, allowFetch = true, fetchBarcodeImage = true) {
       if (!cacheReady) await this.ensureProcessCache()
@@ -1155,15 +1258,15 @@ export default {
       if (input === null) return
       const prepared = config.prepare ? config.prepare.call(this, input) : input
       if (prepared === undefined) return
-      const tasks = []
-      group.indexes.slice().forEach(idx => {
+      const tasks = group.indexes.slice().map(idx => (async () => {
         const record = this.preview[idx]
         if (!record) return
         const result = config.apply.call(this, record, prepared, idx)
         if (result && typeof result.then === 'function') {
-          tasks.push(result)
+          await result
         }
-      })
+        await this.autoSaveRecord(record)
+      })())
       Promise.all(tasks).finally(() => {
         this.ensureCurrentPageContainsFilter()
       })
@@ -1200,14 +1303,13 @@ export default {
         records: []
       }
     },
-    applyBulkUpdates(payload) {
+    async applyBulkUpdates(payload) {
       if (!payload || !payload.type || !Array.isArray(payload.updates)) {
         this.closeBulkModal()
         return
       }
       const { type, updates } = payload
-      const tasks = []
-      updates.forEach(item => {
+      const tasks = updates.map(item => (async () => {
         if (!item || typeof item.index !== 'number') return
         const record = this.preview[item.index]
         if (!record) return
@@ -1230,21 +1332,15 @@ export default {
             } else {
               const name = record.processName != null ? String(record.processName).trim() : ''
               if (name && !this.processCache[name]) this.$set(this.processCache, name, code)
-              const task = this.updateBarcode(record)
-              if (task && typeof task.then === 'function') {
-                tasks.push(task.then(() => this.rememberProcessCode(record)))
-              } else {
-                const remember = this.rememberProcessCode(record)
-                if (remember && typeof remember.then === 'function') tasks.push(remember)
-              }
+              await this.updateBarcode(record)
+              await this.rememberProcessCode(record)
             }
             break
           }
           case '工序': {
             const name = item.processName != null ? String(item.processName).trim() : ''
             record.processName = name
-            const task = this.updateProcess(record)
-            if (task && typeof task.then === 'function') tasks.push(task)
+            await this.updateProcess(record)
             break
           }
           case '计划数': {
@@ -1256,11 +1352,14 @@ export default {
           default:
             break
         }
-      })
-      Promise.all(tasks).finally(() => {
+        await this.autoSaveRecord(record)
+      })())
+      try {
+        await Promise.all(tasks)
+      } finally {
         this.closeBulkModal()
         this.ensureCurrentPageContainsFilter()
-      })
+      }
     }
   }
 }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -72,32 +72,48 @@
             </thead>
 
             <tbody>
-              <tr v-for="entry in item.page.entries" :key="entry.index" :class="{'table-danger': entry.record.codeMissing || entry.record.hoursMissing}">
-                <td class="notification-col">{{ entry.record.notificationNumber }}</td>
-                <td class="no-print">{{ entry.record.productName }}</td>
-                <td class="drawing-col">{{ entry.record.drawingNumber }}</td>
+              <tr
+                v-for="entry in item.page.entries"
+                :key="entry.index"
+                :class="{ 'table-danger': entry.record.hasIssue }"
+                :title="entry.record.issueSummary || ''"
+              >
+                <td :class="['notification-col', { 'missing-cell': entry.record.notificationMissing }]"><span>{{ entry.record.notificationNumber }}</span></td>
+                <td :class="['no-print', { 'missing-cell': entry.record.productMissing }]">{{ entry.record.productName }}</td>
+                <td :class="['drawing-col', { 'missing-cell': entry.record.drawingMissing }]">{{ entry.record.drawingNumber }}</td>
                 <td class="print-only plan-col">{{ entry.record.planQty }}</td>
-                <td class="no-print">{{ entry.record.partName }}</td>
-                <td class="plan-col no-print">
-                  <input type="number" class="form-control form-control-sm" v-model.number="entry.record.planQty" />
+                <td :class="['no-print', { 'missing-cell': entry.record.partMissing }]">{{ entry.record.partName }}</td>
+                <td :class="['plan-col', 'no-print', { 'missing-cell': entry.record.planMissing }]">
+                  <input
+                    type="number"
+                    class="form-control form-control-sm"
+                    :class="{ 'is-invalid': entry.record.planMissing }"
+                    v-model.number="entry.record.planQty"
+                    @input="handlePlanInput(entry.record)"
+                    @blur="handlePlanInput(entry.record)"
+                  />
                   <span class="print-text">{{ entry.record.planQty }}</span>
                 </td>
-                <td class="hours-col">
+                <td :class="['hours-col', { 'missing-cell': entry.record.hoursMissing }]">
                   <input
                     type="number"
                     class="form-control form-control-sm no-print"
                     style="width:80px"
                     v-model.number="entry.record.hours"
+                    :class="{ 'is-invalid': entry.record.hoursMissing }"
+                    @input="checkHours(entry.record)"
                     @blur="checkHours(entry.record)"
                   />
                   <span class="print-text">{{ entry.record.hours }}</span>
                 </td>
-                <td class="no-print">{{ entry.record.processCode }}</td>
-                <td class="process-col">
+                <td :class="['no-print', { 'missing-cell': entry.record.codeMissing }]">{{ entry.record.processCode }}</td>
+                <td :class="['process-col', { 'missing-cell': entry.record.processMissing || entry.record.codeMissing }]">
                   <input
                     class="form-control form-control-sm no-print"
                     v-model="entry.record.processName"
                     @blur="updateProcess(entry.record)"
+                    @input="handleProcessInput(entry.record)"
+                    :class="{ 'is-invalid': entry.record.processMissing || entry.record.codeMissing }"
                   />
                   <span class="print-text">{{ entry.record.processName }}</span>
                 </td>
@@ -106,11 +122,12 @@
                 <td class="print-only time-col"></td>
                 <td class="print-only time-col"></td>
                 <td class="print-only inspector-col"></td>
-                <td class="barcode-cell">
+                <td :class="['barcode-cell', { 'missing-cell': entry.record.barcodeMissing }]">
                   <div>{{ entry.record.barcode }}</div>
                   <img v-if="entry.record.barcodeImage" :src="'data:image/png;base64,'+entry.record.barcodeImage" />
                 </td>
                 <td class="no-print">
+                  <div v-if="entry.record.issueSummary" class="issue-tag mb-1">⚠️ {{ entry.record.issueSummary }}</div>
                   <button class="btn btn-sm btn-outline-primary me-1" @click="addRow(entry.index)">新增</button>
                   <button class="btn btn-sm btn-outline-danger" @click="deleteRow(entry.index)">删除</button>
                 </td>
@@ -253,6 +270,85 @@ export default {
     }
   },
   methods: {
+    hasText(value) {
+      if (value === null || value === undefined) return false
+      return String(value).trim().length > 0
+    },
+    decorateRecord(raw) {
+      const record = { ...raw }
+      record.notificationNumber = record.notificationNumber != null ? String(record.notificationNumber).trim() : ''
+      record.productName = record.productName != null ? String(record.productName).trim() : ''
+      record.drawingNumber = record.drawingNumber != null ? String(record.drawingNumber).trim() : ''
+      record.partName = record.partName != null ? String(record.partName).trim() : ''
+      if (record.planQty !== null && record.planQty !== undefined && record.planQty !== '') {
+        const num = Number(record.planQty)
+        record.planQty = Number.isNaN(num) ? null : num
+      } else {
+        record.planQty = null
+      }
+      if (record.hours !== null && record.hours !== undefined && record.hours !== '') {
+        const num = Number(record.hours)
+        record.hours = Number.isNaN(num) ? null : num
+      } else {
+        record.hours = null
+      }
+      record.barcode = this.sanitize(record.barcode)
+      record.barcodeImage = record.barcodeImage || ''
+      record.workerCodes = record.workerCodes || ''
+      record.qualifiedQty = record.qualifiedQty != null ? Number(record.qualifiedQty) : null
+      record.hourSubtotal = record.hourSubtotal != null ? Number(record.hourSubtotal) : null
+      record.codeMissing = record.codeMissing === true
+      record.hoursMissing = record.hoursMissing === true
+      record.notificationMissing = record.notificationMissing === true
+      record.productMissing = record.productMissing === true
+      record.partMissing = record.partMissing === true
+      record.drawingMissing = record.drawingMissing === true
+      record.planMissing = record.planMissing === true
+      record.processMissing = record.processMissing === true
+      record.barcodeMissing = record.barcodeMissing === true
+      record.issueSummary = ''
+      record.hasIssue = false
+      this.updateIssueFlags(record)
+      return record
+    },
+    updateIssueFlags(record) {
+      if (!record) return
+      const issues = []
+      record.notificationMissing = !this.hasText(record.notificationNumber)
+      if (record.notificationMissing) issues.push('通知单号')
+
+      record.productMissing = !this.hasText(record.productName)
+      if (record.productMissing) issues.push('产品名称')
+
+      record.partMissing = !this.hasText(record.partName)
+      if (record.partMissing) issues.push('名称')
+
+      record.drawingMissing = !this.hasText(record.drawingNumber)
+      if (record.drawingMissing) issues.push('图号')
+
+      record.planMissing = record.planQty === null || record.planQty === undefined || Number.isNaN(record.planQty)
+      if (record.planMissing) issues.push('计划数')
+
+      record.processMissing = !this.hasText(record.processName)
+      if (record.processMissing) issues.push('工序')
+
+      record.hoursMissing = record.hours === null || record.hours === undefined || record.hours === '' || Number.isNaN(record.hours)
+      if (record.hoursMissing) issues.push('单件工时')
+
+      const hasProcessCode = this.hasText(record.processCode)
+      record.codeMissing = record.codeMissing === true || !hasProcessCode
+      if (record.codeMissing) issues.push('工序代码')
+
+      const sanitizedBarcode = this.hasText(record.barcode) ? this.sanitize(String(record.barcode)) : ''
+      if (sanitizedBarcode !== record.barcode) {
+        record.barcode = sanitizedBarcode
+      }
+      record.barcodeMissing = !this.hasText(sanitizedBarcode)
+      if (record.barcodeMissing) issues.push('条形码')
+
+      record.hasIssue = issues.length > 0
+      record.issueSummary = record.hasIssue ? `缺少：${issues.join('、')}` : ''
+    },
     handleRequestError(error, fallback) {
       if (error instanceof Error && error.message === 'missing-user') return
       console.error(error)
@@ -294,12 +390,11 @@ export default {
         if (!Array.isArray(res.data) || !res.data.length) {
           alert('未找到该文件的记录'); this.preview = []
         } else {
-          this.preview = res.data.map(r => ({
+          this.preview = res.data.map(r => this.decorateRecord({
             ...r,
-            barcode: this.sanitize(r.barcode),
             barcodeImage: '',
-            codeMissing: !r.processCode,
-            hoursMissing: r.hours == null
+            codeMissing: r.codeMissing,
+            hoursMissing: r.hoursMissing
           }))
         }
         this.fileId = this.selectedFileId
@@ -353,25 +448,24 @@ export default {
         if (!total) this.parseProgress = 100
         for (let i = 0; i < records.length; i++) {
           const r = records[i] || {}
-          processed.push({
+          processed.push(this.decorateRecord({
             ...r,
             workerCodes: '',
             qualifiedQty: null,
             hourSubtotal: null,
-            barcode: this.sanitize(r.barcode),
             barcodeImage: '',
             codeMissing: !!r.codeMissing,
             hoursMissing: r.hours == null
-          })
+          }))
           if (total) {
             const percent = Math.min(100, Math.round(((i + 1) / total) * 100))
             if (percent > this.parseProgress) this.parseProgress = percent
           }
           if ((i + 1) % 50 === 0) { await new Promise(resolve => setTimeout(resolve, 0)) }
         }
-        const warn = processed.filter(r => r.codeMissing || r.hoursMissing)
+        const warn = processed.filter(r => r.hasIssue)
         this.preview = processed
-        if (warn.length) alert(`发现${warn.length}条记录缺少单件工时或工序码，请检查`)
+        if (warn.length) alert(`发现${warn.length}条记录缺少必填信息，请检查`)
         await this.fetchFiles()
         this.currentPage = 0
         this.$nextTick(() => {
@@ -469,6 +563,18 @@ export default {
         this.processCache = map; this.processCacheLoaded = true
       } catch (e) { console.error('加载工序缓存失败', e) }
     },
+    handleProcessInput(record) {
+      if (!record) return
+      record.processCode = ''
+      record.codeMissing = true
+      record.barcode = ''
+      record.barcodeImage = ''
+      this.updateIssueFlags(record)
+    },
+    handlePlanInput(record) {
+      if (!record) return
+      this.updateIssueFlags(record)
+    },
     async updateProcess(r, cacheReady = false, allowFetch = true, fetchBarcodeImage = true) {
       if (!cacheReady) await this.ensureProcessCache()
       const rawName = r.processName || ''; const name = rawName.trim()
@@ -485,8 +591,12 @@ export default {
       }
       if (code) { r.processCode = code; r.codeMissing = false } else { r.processCode = rawName; r.codeMissing = true }
       await this.updateBarcode(r, fetchBarcodeImage)
+      this.updateIssueFlags(r)
     },
-    async checkHours(r) { r.hoursMissing = r.hours == null || r.hours === '' },
+    checkHours(r) {
+      r.hoursMissing = r.hours == null || r.hours === ''
+      this.updateIssueFlags(r)
+    },
     deleteRow(index) {
       if (!confirm('确定删除该行? 删除后不可恢复')) return
       this.preview.splice(index, 1)
@@ -513,7 +623,8 @@ export default {
         codeMissing: true,
         hoursMissing: true
       }
-      this.preview.splice(index + 1, 0, blank)
+      const decorated = this.decorateRecord(blank)
+      this.preview.splice(index + 1, 0, decorated)
       this.$nextTick(() => this.ensurePageInRange())
     },
     deleteZero() {
@@ -524,6 +635,7 @@ export default {
         const code = r.processCode != null ? String(r.processCode).trim() : ''
         return code !== '0'
       })
+      this.preview.forEach(r => this.updateIssueFlags(r))
       const removed = before - this.preview.length
       alert(`已删除${removed}行`)
     },
@@ -536,6 +648,7 @@ export default {
         const code = this.sanitize(entry.record.barcode)
         if (code !== entry.record.barcode) {
           this.$set(entry.record, 'barcode', code)
+          this.updateIssueFlags(entry.record)
         }
         if (!code) continue
         if (!this.barcodeCache[code] && !entry.record.barcodeImage) missing.push(code)
@@ -604,6 +717,7 @@ export default {
         if (code && this.barcodeCache[code] && record.barcodeImage !== this.barcodeCache[code]) {
           this.$set(record, 'barcodeImage', this.barcodeCache[code])
         }
+        this.updateIssueFlags(record)
       }
     },
     async refreshProcesses() {
@@ -646,6 +760,7 @@ export default {
           else { r.barcodeImage = '' }
         } catch (e) { console.error('获取条码失败', e); r.barcodeImage = '' }
       } else { r.barcode = ''; r.barcodeImage = '' }
+      this.updateIssueFlags(r)
     },
     prevPage() { if (this.currentPage > 0) this.currentPage -= 1 },
     nextPage() { if (this.currentPage < this.pages.length - 1) this.currentPage += 1 },

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -133,25 +133,6 @@
                 </td>
               </tr>
 
-              <!-- 仍然渲染补白行，但屏幕隐藏、打印显示（见 style.css） -->
-              <tr v-for="n in item.page.blankCount" :key="'blank-'+item.index+'-'+n" class="blank-row">
-                <td class="notification-col">&nbsp;</td>
-                <td class="no-print">&nbsp;</td>
-                <td class="drawing-col">&nbsp;</td>
-                <td class="print-only plan-col">&nbsp;</td>
-                <td class="no-print">&nbsp;</td>
-                <td class="plan-col no-print">&nbsp;</td>
-                <td class="hours-col">&nbsp;</td>
-                <td class="no-print">&nbsp;</td>
-                <td class="process-col">&nbsp;</td>
-                <td class="print-only worker-code-col">&nbsp;</td>
-                <td class="print-only qualified-col">&nbsp;</td>
-                <td class="print-only time-col">&nbsp;</td>
-                <td class="print-only time-col">&nbsp;</td>
-                <td class="print-only inspector-col">&nbsp;</td>
-                <td class="barcode-cell"><div>&nbsp;</div></td>
-                <td class="no-print"></td>
-              </tr>
             </tbody>
           </table>
         </div>
@@ -221,18 +202,15 @@ export default {
           pages.push({
             drawingNumber: group.drawingNumber,
             entries: [],
-            blankCount: size,
             isFirstOfDrawing: true
           })
           return
         }
         for (let offset = 0; offset < group.entries.length; offset += size) {
           const slice = group.entries.slice(offset, offset + size)
-          const blanks = size > slice.length ? size - slice.length : 0
           pages.push({
             drawingNumber: group.drawingNumber,
             entries: slice,
-            blankCount: blanks,
             isFirstOfDrawing: offset === 0
           })
         }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -417,6 +417,9 @@ export default {
       record.issueSummary = ''
       record.hasIssue = false
       record.issueTypes = []
+      record._lastAcceptedProcessCode = record.processCode
+      record._lastAcceptedBarcode = record.barcode
+      record._lastAcceptedBarcodeImage = record.barcodeImage
       this.updateIssueFlags(record)
       return record
     },
@@ -761,23 +764,63 @@ export default {
       }
     },
     async rememberProcessCode(record) {
-      if (!record) return
+      if (!record) return false
       const name = record.processName != null ? String(record.processName).trim() : ''
       const code = record.processCode != null ? String(record.processCode).trim() : ''
-      if (!name || !code) return
+      if (!name || !code) return false
       const key = `${name}|||${code}`
-      if (this.rememberedPairs[key]) return
+      if (this.rememberedPairs[key]) {
+        record._lastAcceptedProcessCode = code
+        record._lastAcceptedBarcode = record.barcode
+        record._lastAcceptedBarcodeImage = record.barcodeImage
+        if (!this.processCache[name] || this.processCache[name] !== code) {
+          this.$set(this.processCache, name, code)
+        }
+        return true
+      }
       let headers
       try { headers = this.requireUserHeaders() }
-      catch (err) { return }
+      catch (err) { return false }
+      const previousCode = record._lastAcceptedProcessCode != null ? String(record._lastAcceptedProcessCode).trim() : ''
+      const previousBarcode = record._lastAcceptedBarcode || ''
+      const previousImage = record._lastAcceptedBarcodeImage || ''
       try {
         await axios.post('/api/processcodes/remember', { name, code }, { headers })
         this.$set(this.rememberedPairs, key, true)
-        if (!this.processCache[name]) {
+        if (!this.processCache[name] || this.processCache[name] !== code) {
           this.$set(this.processCache, name, code)
         }
+        record._lastAcceptedProcessCode = code
+        record._lastAcceptedBarcode = record.barcode
+        record._lastAcceptedBarcodeImage = record.barcodeImage
+        return true
       } catch (error) {
-        console.error('记住工序代码失败', error)
+        this.handleRequestError(error, '保存工序代码失败')
+        if (this.processCache[name] === code) {
+          if (this.hasText(previousCode)) {
+            this.$set(this.processCache, name, previousCode)
+          } else if (this.$delete) {
+            this.$delete(this.processCache, name)
+          } else {
+            delete this.processCache[name]
+          }
+        }
+        if (previousCode !== code) {
+          record.processCode = previousCode
+        }
+        if (this.hasText(previousCode)) {
+          record.serverCodeMissing = false
+          record.codeMissing = false
+          record.barcode = previousBarcode
+          record.barcodeImage = previousImage
+        } else {
+          record.serverCodeMissing = true
+          record.codeMissing = true
+          record.barcode = ''
+          record.barcodeImage = ''
+        }
+        this.updateIssueFlags(record)
+        return false
       }
     },
     async ensureProcessCache(force = false) {
@@ -831,10 +874,18 @@ export default {
         await this.autoSaveRecord(record)
         return
       }
+      const previousBarcode = record.barcode
+      const previousImage = record.barcodeImage
       record.serverCodeMissing = false
       record.codeMissing = false
       await this.updateBarcode(record)
-      await this.rememberProcessCode(record)
+      const success = await this.rememberProcessCode(record)
+      if (!success) {
+        record.barcode = previousBarcode
+        record.barcodeImage = previousImage
+        return
+      }
+      this.updateIssueFlags(record)
       await this.autoSaveRecord(record)
     },
     handlePlanInput(record) {
@@ -1313,6 +1364,7 @@ export default {
         if (!item || typeof item.index !== 'number') return
         const record = this.preview[item.index]
         if (!record) return
+        let shouldSave = true
         switch (type) {
           case '单件工时': {
             const value = item.hours
@@ -1332,8 +1384,18 @@ export default {
             } else {
               const name = record.processName != null ? String(record.processName).trim() : ''
               if (name && !this.processCache[name]) this.$set(this.processCache, name, code)
+              const previousBarcode = record.barcode
+              const previousImage = record.barcodeImage
               await this.updateBarcode(record)
-              await this.rememberProcessCode(record)
+              const success = await this.rememberProcessCode(record)
+              if (!success) {
+                record.barcode = previousBarcode
+                record.barcodeImage = previousImage
+                shouldSave = false
+              } else {
+                record.serverCodeMissing = false
+                record.codeMissing = false
+              }
             }
             break
           }
@@ -1352,7 +1414,9 @@ export default {
           default:
             break
         }
-        await this.autoSaveRecord(record)
+        if (shouldSave) {
+          await this.autoSaveRecord(record)
+        }
       })())
       try {
         await Promise.all(tasks)

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -122,7 +122,17 @@
                     />
                     <span class="print-text">{{ entry.record.hours }}</span>
                   </td>
-                  <td :class="['no-print', { 'missing-cell': entry.record.codeMissing }]">{{ entry.record.processCode }}</td>
+                  <td :class="['no-print', { 'missing-cell': entry.record.codeMissing }]">
+                    <input
+                      type="text"
+                      class="form-control form-control-sm"
+                      v-model="entry.record.processCode"
+                      placeholder="填写工序代码"
+                      @input="handleProcessCodeTyping(entry.record)"
+                      @blur="handleProcessCodeBlur(entry.record)"
+                    />
+                    <span class="print-text">{{ entry.record.processCode }}</span>
+                  </td>
                   <td :class="['process-col', { 'missing-cell': entry.record.processMissing || entry.record.codeMissing }]">
                     <input
                       class="form-control form-control-sm no-print"
@@ -155,14 +165,23 @@
         </template>
       </div>
     </div>
+    <BulkIssueModal
+      :visible="bulkModal.visible"
+      :type="bulkModal.type"
+      :group="bulkModal.group"
+      :records="bulkModal.records"
+      @close="closeBulkModal"
+      @apply="applyBulkUpdates"
+    />
   </section>
 </template>
 
 <script>
 import axios from 'axios'
 import RecordIssuePanel from './RecordIssuePanel.vue'
+import BulkIssueModal from './BulkIssueModal.vue'
 export default {
-  components: { RecordIssuePanel },
+  components: { RecordIssuePanel, BulkIssueModal },
   data() {
     return {
       file: null,
@@ -182,7 +201,13 @@ export default {
       renderAllPages: false,
       renderBuffer: 0,
       issueFilter: null,
-      issueCompletionNotified: false
+      issueCompletionNotified: false,
+      bulkModal: {
+        visible: false,
+        type: '',
+        group: null,
+        records: []
+      }
     }
   },
   created() {
@@ -674,6 +699,35 @@ export default {
       record.barcodeImage = ''
       this.updateIssueFlags(record)
     },
+    handleProcessCodeTyping(record) {
+      if (!record) return
+      const value = record.processCode != null ? String(record.processCode) : ''
+      const hasValue = this.hasText(value)
+      record.serverCodeMissing = !hasValue
+      record.codeMissing = !hasValue
+      if (!hasValue) {
+        record.barcode = ''
+        record.barcodeImage = ''
+      }
+      this.updateIssueFlags(record)
+    },
+    async handleProcessCodeBlur(record) {
+      if (!record) return
+      const value = record.processCode != null ? String(record.processCode).trim() : ''
+      record.processCode = value
+      if (!value) {
+        record.serverCodeMissing = true
+        record.codeMissing = true
+        record.barcode = ''
+        record.barcodeImage = ''
+        this.updateIssueFlags(record)
+        return
+      }
+      record.serverCodeMissing = false
+      record.codeMissing = false
+      await this.updateBarcode(record)
+      this.updateIssueFlags(record)
+    },
     handlePlanInput(record) {
       if (!record) return
       this.updateIssueFlags(record)
@@ -701,16 +755,19 @@ export default {
           }
         } catch (e) { /* ignore */ }
       }
+      const manualCode = this.hasText(existingCode) ? existingCode : ''
       if (code) {
         r.processCode = code
         r.serverCodeMissing = false
-      } else if (existingCode && r.serverCodeMissing !== true) {
-        r.processCode = existingCode
+      } else if (manualCode) {
+        r.processCode = manualCode
+        r.serverCodeMissing = false
+        if (!this.processCache[name]) this.$set(this.processCache, name, manualCode)
       } else {
         r.processCode = ''
         r.serverCodeMissing = true
       }
-      r.codeMissing = !this.hasText(r.processCode) || r.serverCodeMissing === true
+      r.codeMissing = !this.hasText(r.processCode)
       await this.updateBarcode(r, fetchBarcodeImage)
       this.updateIssueFlags(r)
     },
@@ -1056,6 +1113,10 @@ export default {
     },
     handleBulkFill(group) {
       if (!group) return
+      if (group.type === '单件工时' || group.type === '工序代码') {
+        this.openBulkModal(group)
+        return
+      }
       const config = this.getBulkConfig(group.type)
       if (!config) {
         alert('该缺陷暂不支持批量填写')
@@ -1075,6 +1136,95 @@ export default {
         }
       })
       Promise.all(tasks).finally(() => {
+        this.ensureCurrentPageContainsFilter()
+      })
+    },
+    openBulkModal(group) {
+      if (!group) return
+      const records = group.indexes
+        .map(idx => {
+          const record = this.preview[idx]
+          if (!record) return null
+          return {
+            index: idx,
+            notificationNumber: record.notificationNumber,
+            drawingNumber: record.drawingNumber,
+            processName: record.processName,
+            processCode: record.processCode,
+            hours: record.hours,
+            planQty: record.planQty
+          }
+        })
+        .filter(Boolean)
+      this.bulkModal = {
+        visible: true,
+        type: group.type,
+        group,
+        records
+      }
+    },
+    closeBulkModal() {
+      this.bulkModal = {
+        visible: false,
+        type: '',
+        group: null,
+        records: []
+      }
+    },
+    applyBulkUpdates(payload) {
+      if (!payload || !payload.type || !Array.isArray(payload.updates)) {
+        this.closeBulkModal()
+        return
+      }
+      const { type, updates } = payload
+      const tasks = []
+      updates.forEach(item => {
+        if (!item || typeof item.index !== 'number') return
+        const record = this.preview[item.index]
+        if (!record) return
+        switch (type) {
+          case '单件工时': {
+            const value = item.hours
+            record.hours = value === '' || value === null || Number.isNaN(Number(value)) ? null : Number(value)
+            this.checkHours(record)
+            break
+          }
+          case '工序代码': {
+            const code = item.processCode != null ? String(item.processCode).trim() : ''
+            record.processCode = code
+            record.serverCodeMissing = !this.hasText(code)
+            record.codeMissing = !this.hasText(code)
+            if (!this.hasText(code)) {
+              record.barcode = ''
+              record.barcodeImage = ''
+              this.updateIssueFlags(record)
+            } else {
+              const name = record.processName != null ? String(record.processName).trim() : ''
+              if (name && !this.processCache[name]) this.$set(this.processCache, name, code)
+              const task = this.updateBarcode(record)
+              if (task && typeof task.then === 'function') tasks.push(task)
+            }
+            break
+          }
+          case '工序': {
+            const name = item.processName != null ? String(item.processName).trim() : ''
+            record.processName = name
+            const task = this.updateProcess(record)
+            if (task && typeof task.then === 'function') tasks.push(task)
+            break
+          }
+          case '计划数': {
+            const plan = item.planQty
+            record.planQty = plan === '' || plan === null || Number.isNaN(Number(plan)) ? null : Number(plan)
+            this.handlePlanInput(record)
+            break
+          }
+          default:
+            break
+        }
+      })
+      Promise.all(tasks).finally(() => {
+        this.closeBulkModal()
         this.ensureCurrentPageContainsFilter()
       })
     }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -207,7 +207,8 @@ export default {
         type: '',
         group: null,
         records: []
-      }
+      },
+      rememberedPairs: Object.create(null)
     }
   },
   created() {
@@ -360,12 +361,12 @@ export default {
         if (match) {
           this.issueFilter.indexes = match.indexes.slice()
           if (!match.count) {
-            this.advanceToNextIssueGroup(newGroups)
+            this.handleIssueGroupCleared(newGroups)
           } else {
             this.$nextTick(() => this.ensureCurrentPageContainsFilter())
           }
         } else {
-          this.advanceToNextIssueGroup(newGroups)
+          this.handleIssueGroupCleared(newGroups)
         }
       },
       deep: true
@@ -673,6 +674,26 @@ export default {
       }
       return result
     },
+    async rememberProcessCode(record) {
+      if (!record) return
+      const name = record.processName != null ? String(record.processName).trim() : ''
+      const code = record.processCode != null ? String(record.processCode).trim() : ''
+      if (!name || !code) return
+      const key = `${name}|||${code}`
+      if (this.rememberedPairs[key]) return
+      let headers
+      try { headers = this.requireUserHeaders() }
+      catch (err) { return }
+      try {
+        await axios.post('/api/processcodes/remember', { name, code }, { headers })
+        this.$set(this.rememberedPairs, key, true)
+        if (!this.processCache[name]) {
+          this.$set(this.processCache, name, code)
+        }
+      } catch (error) {
+        console.error('记住工序代码失败', error)
+      }
+    },
     async ensureProcessCache(force = false) {
       if (this.processCacheLoaded && !force) return
       try {
@@ -726,7 +747,7 @@ export default {
       record.serverCodeMissing = false
       record.codeMissing = false
       await this.updateBarcode(record)
-      this.updateIssueFlags(record)
+      await this.rememberProcessCode(record)
     },
     handlePlanInput(record) {
       if (!record) return
@@ -737,6 +758,7 @@ export default {
       const rawName = r.processName || ''
       const name = rawName.trim()
       const existingCode = r.processCode != null ? String(r.processCode).trim() : ''
+      let shouldRemember = false
       if (!name) {
         r.processCode = ''
         r.serverCodeMissing = false
@@ -763,6 +785,7 @@ export default {
         r.processCode = manualCode
         r.serverCodeMissing = false
         if (!this.processCache[name]) this.$set(this.processCache, name, manualCode)
+        shouldRemember = true
       } else {
         r.processCode = ''
         r.serverCodeMissing = true
@@ -770,6 +793,9 @@ export default {
       r.codeMissing = !this.hasText(r.processCode)
       await this.updateBarcode(r, fetchBarcodeImage)
       this.updateIssueFlags(r)
+      if (shouldRemember && !r.codeMissing) {
+        await this.rememberProcessCode(r)
+      }
     },
     checkHours(r) {
       r.hoursMissing = r.hours == null || r.hours === ''
@@ -993,27 +1019,30 @@ export default {
       this.issueCompletionNotified = false
       this.currentPage = 0
     },
-    advanceToNextIssueGroup(groups) {
-      const remaining = groups.filter(group => group.count > 0)
-      if (!remaining.length) {
-        const hadFilter = !!this.issueFilter
-        this.issueFilter = null
-        if (hadFilter && !this.issueCompletionNotified) {
+    handleIssueGroupCleared(groups) {
+      const remaining = Array.isArray(groups) ? groups.filter(group => group.count > 0) : []
+      const previousPage = this.currentPage
+      const hadFilter = !!this.issueFilter
+      this.issueFilter = null
+      this.$nextTick(() => {
+        if (!this.pages.length) {
+          this.currentPage = 0
+          return
+        }
+        let target = previousPage
+        if (target >= this.pages.length) target = this.pages.length - 1
+        if (target < 0) target = 0
+        this.currentPage = target
+      })
+      if (!hadFilter) return
+      if (!this.issueCompletionNotified) {
+        if (!remaining.length) {
           alert('所有缺陷已处理完毕！')
-          this.issueCompletionNotified = true
+        } else {
+          alert('当前缺陷已处理完毕，请检查页面后再选择其它缺陷。')
         }
-        return
+        this.issueCompletionNotified = true
       }
-      this.issueCompletionNotified = false
-      const currentKey = this.issueFilter ? this.issueFilter.key : null
-      let next = remaining[0]
-      if (currentKey) {
-        const idx = remaining.findIndex(group => group.key === currentKey)
-        if (idx >= 0) {
-          next = remaining[(idx + 1) % remaining.length]
-        }
-      }
-      this.selectIssueGroup(next)
     },
     ensureCurrentPageContainsFilter() {
       if (!this.issueFilter) return
@@ -1202,7 +1231,12 @@ export default {
               const name = record.processName != null ? String(record.processName).trim() : ''
               if (name && !this.processCache[name]) this.$set(this.processCache, name, code)
               const task = this.updateBarcode(record)
-              if (task && typeof task.then === 'function') tasks.push(task)
+              if (task && typeof task.then === 'function') {
+                tasks.push(task.then(() => this.rememberProcessCode(record)))
+              } else {
+                const remember = this.rememberProcessCode(record)
+                if (remember && typeof remember.then === 'function') tasks.push(remember)
+              }
             }
             break
           }

--- a/frontend/src/components/WorkerManager.vue
+++ b/frontend/src/components/WorkerManager.vue
@@ -99,7 +99,7 @@ export default {
       this.workers = res.data
     },
     async createWorker() {
-      await axios.post('`/api/workers', this.newWorker)
+      await axios.post('/api/workers', this.newWorker)
       this.closeModal()
       this.fetchWorkers(this.search)
     },


### PR DESCRIPTION
## Summary
- request non-persistent parsing so the Excel upload page immediately shows returned records and align barcode sanitisation across tiers
- add a bulk process-code lookup endpoint and client caching to avoid sequential requests before saving records
- make worktime Excel import tolerate formatted cells and fix worker creation API usage and logout handling

## Testing
- npm run build
- mvn -q -f backend/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68f308ff4e00832c9ee5232594a47a60