### PR TITLE
Persist parsed uploads to database

### DIFF
--- a/backend/src/main/java/com/example/worktime/controller/AuthController.java
+++ b/backend/src/main/java/com/example/worktime/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.worktime.controller;
 
 import com.example.worktime.model.User;
 import com.example.worktime.repository.UserRepository;
+import com.example.worktime.service.OperationLogContext;
 import com.example.worktime.service.OperationLogService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -13,10 +14,12 @@ import org.springframework.web.server.ResponseStatusException;
 public class AuthController {
     private final UserRepository repository;
     private final OperationLogService logService;
+    private final OperationLogContext logContext;
 
-    public AuthController(UserRepository repository, OperationLogService logService) {
+    public AuthController(UserRepository repository, OperationLogService logService, OperationLogContext logContext) {
         this.repository = repository;
         this.logService = logService;
+        this.logContext = logContext;
     }
 
     @PostMapping("/login")
@@ -24,6 +27,9 @@ public class AuthController {
         if (!repository.findByUsernameAndPassword(user.getUsername(), user.getPassword()).isPresent()) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "账号或密码错误");
         }
+        logContext.setModule("认证");
+        logContext.setEntity("User", user.getUsername());
+        logContext.setSummary("登录成功");
         logService.log(user.getUsername(), "登录", null);
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
+++ b/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
@@ -33,6 +33,14 @@ public class OperationLogController {
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String username,
             @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String module,
+            @RequestParam(required = false) String entityType,
+            @RequestParam(required = false) String entityId,
+            @RequestParam(required = false) String clientIp,
+            @RequestParam(required = false) String traceId,
+            @RequestParam(required = false) Integer statusCode,
+            @RequestParam(required = false) Long minDuration,
+            @RequestParam(required = false) Long maxDuration,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
         int pageIndex = Math.max(page, 0);
@@ -48,8 +56,34 @@ public class OperationLogController {
                 String like = "%" + keyword.trim().toLowerCase() + "%";
                 predicates.add(cb.or(
                         cb.like(cb.lower(root.get("action")), like),
-                        cb.like(cb.lower(root.get("details")), like)
+                        cb.like(cb.lower(root.get("details")), like),
+                        cb.like(cb.lower(root.get("summary")), like)
                 ));
+            }
+            if (StringUtils.hasText(module)) {
+                predicates.add(cb.equal(cb.lower(root.get("module")), module.trim().toLowerCase()));
+            }
+            if (StringUtils.hasText(entityType)) {
+                predicates.add(cb.equal(cb.lower(root.get("entityType")), entityType.trim().toLowerCase()));
+            }
+            if (StringUtils.hasText(entityId)) {
+                predicates.add(cb.equal(root.get("entityId"), entityId.trim()));
+            }
+            if (StringUtils.hasText(clientIp)) {
+                String likeIp = "%" + clientIp.trim().toLowerCase() + "%";
+                predicates.add(cb.like(cb.lower(root.get("clientIp")), likeIp));
+            }
+            if (StringUtils.hasText(traceId)) {
+                predicates.add(cb.equal(root.get("traceId"), traceId.trim()));
+            }
+            if (statusCode != null) {
+                predicates.add(cb.equal(root.get("statusCode"), statusCode));
+            }
+            if (minDuration != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("durationMs"), minDuration));
+            }
+            if (maxDuration != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("durationMs"), maxDuration));
             }
             if (startDate != null) {
                 LocalDateTime start = startDate.atStartOfDay();

--- a/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
+++ b/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
@@ -2,8 +2,18 @@ package com.example.worktime.controller;
 
 import com.example.worktime.model.OperationLog;
 import com.example.worktime.repository.OperationLogRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import javax.persistence.criteria.Predicate;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -17,7 +27,40 @@ public class OperationLogController {
     }
 
     @GetMapping
-    public List<OperationLog> logs() {
-        return repository.findAllByOrderByTimestampDesc();
+    public Page<OperationLog> logs(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String username,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        int pageIndex = Math.max(page, 0);
+        int pageSize = Math.max(1, Math.min(size, 200));
+        Pageable pageable = PageRequest.of(pageIndex, pageSize, Sort.by(Sort.Direction.DESC, "timestamp"));
+
+        Specification<OperationLog> specification = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (username != null && !username.isBlank()) {
+                predicates.add(cb.equal(cb.lower(root.get("username")), username.trim().toLowerCase()));
+            }
+            if (keyword != null && !keyword.isBlank()) {
+                String like = "%" + keyword.trim().toLowerCase() + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("action")), like),
+                        cb.like(cb.lower(root.get("details")), like)
+                ));
+            }
+            if (startDate != null) {
+                LocalDateTime start = startDate.atStartOfDay();
+                predicates.add(cb.greaterThanOrEqualTo(root.get("timestamp"), start));
+            }
+            if (endDate != null) {
+                LocalDateTime end = endDate.plusDays(1).atStartOfDay();
+                predicates.add(cb.lessThan(root.get("timestamp"), end));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        return repository.findAll(specification, pageable);
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
+++ b/backend/src/main/java/com/example/worktime/controller/OperationLogController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import javax.persistence.criteria.Predicate;
@@ -40,10 +41,10 @@ public class OperationLogController {
 
         Specification<OperationLog> specification = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            if (username != null && !username.isBlank()) {
+            if (StringUtils.hasText(username)) {
                 predicates.add(cb.equal(cb.lower(root.get("username")), username.trim().toLowerCase()));
             }
-            if (keyword != null && !keyword.isBlank()) {
+            if (StringUtils.hasText(keyword)) {
                 String like = "%" + keyword.trim().toLowerCase() + "%";
                 predicates.add(cb.or(
                         cb.like(cb.lower(root.get("action")), like),

--- a/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
+++ b/backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java
@@ -2,6 +2,7 @@ package com.example.worktime.controller;
 
 import com.example.worktime.model.ProcessCode;
 import com.example.worktime.repository.ProcessCodeRepository;
+import com.example.worktime.service.OperationLogContext;
 import com.example.worktime.service.OperationLogService;
 import com.example.worktime.service.ProcessCodeService;
 import org.springframework.http.HttpStatus;
@@ -18,13 +19,16 @@ public class ProcessCodeController {
     private final ProcessCodeRepository repository;
     private final OperationLogService logService;
     private final ProcessCodeService processService;
+    private final OperationLogContext logContext;
 
     public ProcessCodeController(ProcessCodeRepository repository,
                                  OperationLogService logService,
-                                 ProcessCodeService processService) {
+                                 ProcessCodeService processService,
+                                 OperationLogContext logContext) {
         this.repository = repository;
         this.logService = logService;
         this.processService = processService;
+        this.logContext = logContext;
     }
 
     @GetMapping
@@ -67,8 +71,16 @@ public class ProcessCodeController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序名称和工序代号均不能为空");
         }
         if (existing == null) {
+            logContext.setModule("工序管理");
+            logContext.setEntity("ProcessCode", saved.getId() != null ? saved.getId().toString() : null);
+            logContext.setSummary("新增工序");
+            logContext.appendDetail("code=" + trimmedCode);
             logService.log(user, "新增工序 " + saved.getName(), "id=" + saved.getId());
         } else {
+            logContext.setModule("工序管理");
+            logContext.setEntity("ProcessCode", existing.getId() != null ? existing.getId().toString() : null);
+            logContext.setSummary("更新工序");
+            logContext.appendDetail("code=" + trimmedCode);
             logService.log(user, "更新工序 " + existing.getId(), null);
         }
         return saved;
@@ -78,6 +90,10 @@ public class ProcessCodeController {
     public ProcessCode create(@RequestBody ProcessCode pc, @RequestHeader("X-User") String user) {
         validate(pc);
         ProcessCode saved = repository.save(pc);
+        logContext.setModule("工序管理");
+        logContext.setEntity("ProcessCode", saved.getId() != null ? saved.getId().toString() : null);
+        logContext.setSummary("新增工序");
+        logContext.appendDetail("code=" + pc.getCode());
         logService.log(user, "新增工序 " + pc.getName(), "id=" + saved.getId());
         return saved;
     }
@@ -87,6 +103,10 @@ public class ProcessCodeController {
         pc.setId(id);
         validate(pc);
         ProcessCode saved = repository.save(pc);
+        logContext.setModule("工序管理");
+        logContext.setEntity("ProcessCode", id != null ? id.toString() : null);
+        logContext.setSummary("更新工序");
+        logContext.appendDetail("code=" + pc.getCode());
         logService.log(user, "更新工序 " + id, null);
         return saved;
     }
@@ -94,6 +114,9 @@ public class ProcessCodeController {
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
         repository.deleteById(id);
+        logContext.setModule("工序管理");
+        logContext.setEntity("ProcessCode", id != null ? id.toString() : null);
+        logContext.setSummary("删除工序");
         logService.log(user, "删除工序 " + id, null);
     }
 

--- a/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
+++ b/backend/src/main/java/com/example/worktime/controller/UploadedFileController.java
@@ -3,6 +3,7 @@ package com.example.worktime.controller;
 import com.example.worktime.model.UploadedFile;
 import com.example.worktime.repository.UploadedFileRepository;
 import com.example.worktime.repository.WorkRecordRepository;
+import com.example.worktime.service.OperationLogContext;
 import com.example.worktime.service.OperationLogService;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -16,12 +17,14 @@ public class UploadedFileController {
     private final UploadedFileRepository repository;
     private final WorkRecordRepository recordRepository;
     private final OperationLogService logService;
+    private final OperationLogContext logContext;
 
     public UploadedFileController(UploadedFileRepository repository, WorkRecordRepository recordRepository,
-                                 OperationLogService logService) {
+                                 OperationLogService logService, OperationLogContext logContext) {
         this.repository = repository;
         this.recordRepository = recordRepository;
         this.logService = logService;
+        this.logContext = logContext;
     }
 
     @GetMapping
@@ -37,6 +40,10 @@ public class UploadedFileController {
         recordRepository.deleteByFileId(id);
         repository.deleteById(id);
         String name = file != null ? file.getFileName() : String.valueOf(id);
+        logContext.setModule("文件管理");
+        logContext.setEntity("UploadedFile", id != null ? id.toString() : null);
+        logContext.setSummary("删除上传文件");
+        logContext.appendDetail("fileName=" + name);
         logService.log(user, "删除文件 " + name, "records=" + cnt);
     }
 }

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -709,6 +709,17 @@ public class WorkRecordController {
             wr.setProcessCode(null);
         }
         boolean codePresent = normalizedCode != null;
+        if (codePresent) {
+            String processName = wr.getProcessName() != null ? wr.getProcessName().trim() : null;
+            if (processName != null && !processName.isEmpty()) {
+                if (normalizedCode.equals(processName)) {
+                    if (!processService.isKnownCode(normalizedCode)) {
+                        codePresent = false;
+                        wr.setProcessCode(null);
+                    }
+                }
+            }
+        }
         boolean codeMissing = Boolean.TRUE.equals(wr.getCodeMissing()) || !codePresent;
         wr.setCodeMissing(codeMissing);
         if (codeMissing) {
@@ -821,13 +832,12 @@ public class WorkRecordController {
                                 }
                             }
                         }
+                        if (code == null && processService.isKnownCode(normalizedProcess)) {
+                            code = normalizedProcess;
+                        }
                     }
-                    boolean codeMissing = false;
-                    if (code == null || code.trim().isEmpty() || "0".equals(code.trim())) {
-                        code = normalizedProcess != null && !normalizedProcess.isEmpty() ? normalizedProcess : process;
-                        codeMissing = true;
-                    }
-                    wr.setProcessCode(code);
+                    boolean codeMissing = code == null || code.trim().isEmpty() || "0".equals(code.trim());
+                    wr.setProcessCode(codeMissing ? null : code);
                     wr.setCodeMissing(codeMissing);
 
                     if (drawing != null && notification != null && code != null && !codeMissing) {

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -702,9 +702,19 @@ public class WorkRecordController {
         boolean hoursMissing = wr.getHours() == null;
         wr.setHoursMissing(hoursMissing);
 
-        boolean codePresent = hasText(wr.getProcessCode());
+        String normalizedCode = normalizeProcessCode(wr.getProcessCode());
+        if (normalizedCode != null) {
+            wr.setProcessCode(normalizedCode);
+        } else {
+            wr.setProcessCode(null);
+        }
+        boolean codePresent = normalizedCode != null;
         boolean codeMissing = Boolean.TRUE.equals(wr.getCodeMissing()) || !codePresent;
         wr.setCodeMissing(codeMissing);
+        if (codeMissing) {
+            wr.setBarcode(null);
+            wr.setBarcodeImage(null);
+        }
 
         String sanitizedBarcode = wr.getBarcode() != null ? sanitizeBarcode(wr.getBarcode()) : null;
         boolean barcodePresent = hasText(sanitizedBarcode);
@@ -714,6 +724,21 @@ public class WorkRecordController {
 
     private boolean hasText(String value) {
         return value != null && !value.trim().isEmpty();
+    }
+
+    private String normalizeProcessCode(String code) {
+        if (code == null) {
+            return null;
+        }
+        String trimmed = code.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        return "0".equals(trimmed) ? null : trimmed;
+    }
+
+    private boolean hasValidProcessCode(String code) {
+        return normalizeProcessCode(code) != null;
     }
 
     private java.util.Set<String> fetchExistingBarcodes(java.util.Collection<String> barcodes) {
@@ -786,21 +811,26 @@ public class WorkRecordController {
                         code = codeCache.get(normalizedProcess);
                         if (code == null) {
                             code = processService.getCode(normalizedProcess);
-                            if (code != null && !code.trim().isEmpty()) {
-                                code = code.trim();
-                                codeCache.put(normalizedProcess, code);
+                            if (code != null) {
+                                String trimmed = code.trim();
+                                if (!trimmed.isEmpty() && !"0".equals(trimmed)) {
+                                    code = trimmed;
+                                    codeCache.put(normalizedProcess, code);
+                                } else {
+                                    code = null;
+                                }
                             }
                         }
                     }
                     boolean codeMissing = false;
-                    if (code == null || code.trim().isEmpty()) {
+                    if (code == null || code.trim().isEmpty() || "0".equals(code.trim())) {
                         code = normalizedProcess != null && !normalizedProcess.isEmpty() ? normalizedProcess : process;
                         codeMissing = true;
                     }
                     wr.setProcessCode(code);
                     wr.setCodeMissing(codeMissing);
 
-                    if (drawing != null && notification != null && code != null) {
+                    if (drawing != null && notification != null && code != null && !codeMissing) {
                         String bar = drawing + "-" + notification + "-" + code;
                         String clean = sanitizeBarcode(bar);
                         wr.setBarcode(clean);
@@ -912,7 +942,7 @@ public class WorkRecordController {
     }
 
     private void validate(WorkRecord record) {
-        if (record.getProcessCode() == null || record.getProcessCode().trim().isEmpty()) {
+        if (!hasValidProcessCode(record.getProcessCode())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "工序代码不能为空");
         }
         if (record.getBarcode() == null || record.getBarcode().trim().isEmpty()) {

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -4,6 +4,7 @@ import com.example.worktime.model.WorkRecord;
 import com.example.worktime.model.UploadedFile;
 import com.example.worktime.repository.WorkRecordRepository;
 import com.example.worktime.repository.UploadedFileRepository;
+import com.example.worktime.service.OperationLogContext;
 import com.example.worktime.service.OperationLogService;
 import com.example.worktime.service.ProcessCodeService;
 import com.example.worktime.service.WorkerService;
@@ -51,17 +52,19 @@ public class WorkRecordController {
     private final WorkerService workerService;
     private final UploadedFileRepository fileRepository;
     private final OperationLogService logService;
+    private final OperationLogContext logContext;
     @PersistenceContext
     private EntityManager entityManager;
 
     public WorkRecordController(WorkRecordRepository repository, ProcessCodeService processService,
                                 WorkerService workerService, UploadedFileRepository fileRepository,
-                                OperationLogService logService) {
+                                OperationLogService logService, OperationLogContext logContext) {
         this.repository = repository;
         this.processService = processService;
         this.workerService = workerService;
         this.fileRepository = fileRepository;
         this.logService = logService;
+        this.logContext = logContext;
     }
 
     @GetMapping
@@ -396,6 +399,9 @@ public class WorkRecordController {
             result.add(repository.save(record));
         }
         repository.flush();
+        logContext.setModule("工时记录");
+        logContext.setSummary("批量更新记录");
+        logContext.appendDetail("count=" + result.size());
         logService.log(user, "批量更新记录", "count=" + result.size());
         return result;
     }
@@ -463,6 +469,10 @@ public class WorkRecordController {
         }
         WorkRecord saved = repository.save(record);
         repository.flush();
+        logContext.setModule("工时记录");
+        logContext.setEntity("WorkRecord", saved.getId() != null ? saved.getId().toString() : null);
+        logContext.setSummary("自动保存记录");
+        logContext.appendDetail("drawing=" + saved.getDrawingNumber());
         logService.log(user, "自动保存记录", "id=" + saved.getId());
         flagIssues(saved);
         return saved;
@@ -485,6 +495,10 @@ public class WorkRecordController {
         record.setNaturalMonth(ym != null ? ym.toString() : null);
         if (record.getQualifiedQty() != null) record.setFilled(true);
         WorkRecord updated = repository.save(record);
+        logContext.setModule("工时记录");
+        logContext.setEntity("WorkRecord", id != null ? id.toString() : null);
+        logContext.setSummary("更新记录");
+        logContext.appendDetail("drawing=" + saved.getDrawingNumber());
         logService.log(user, "更新记录 " + id, null);
         return updated;
     }
@@ -513,6 +527,10 @@ public class WorkRecordController {
         YearMonth ym = determineNaturalMonth(copy);
         copy.setNaturalMonth(ym != null ? ym.toString() : null);
         WorkRecord saved = repository.save(copy);
+        logContext.setModule("工时记录");
+        logContext.setEntity("WorkRecord", saved.getId() != null ? saved.getId().toString() : null);
+        logContext.setSummary("复制记录");
+        logContext.appendDetail("sourceId=" + id);
         logService.log(user, "复制记录 " + id, "newId=" + saved.getId());
         return saved;
     }
@@ -522,6 +540,9 @@ public class WorkRecordController {
     public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
         repository.deleteById(id);
         repository.flush();
+        logContext.setModule("工时记录");
+        logContext.setEntity("WorkRecord", id != null ? id.toString() : null);
+        logContext.setSummary("删除记录");
         logService.log(user, "删除记录 " + id, null);
     }
 
@@ -555,6 +576,10 @@ public class WorkRecordController {
         }
         java.util.List<WorkRecord> saved = repository.saveAll(records);
         repository.flush();
+        logContext.setModule("工时记录");
+        logContext.setSummary("新增记录");
+        logContext.setEntity("UploadedFile", fileId != null ? fileId.toString() : null);
+        logContext.appendDetail("count=" + saved.size());
         logService.log(user, "新增记录" , "fileId=" + fileId + " count=" + saved.size());
         return saved;
     }
@@ -616,6 +641,11 @@ public class WorkRecordController {
         result.put("codeMissing", codeMissing);
         result.put("hoursMissing", hoursMissing);
         result.put("records", parsed);
+        logContext.setModule("工时记录");
+        logContext.setEntity("UploadedFile", uf.getId() != null ? uf.getId().toString() : null);
+        logContext.setSummary("上传文件");
+        logContext.appendDetail("fileName=" + uf.getFileName());
+        logContext.appendDetail("records=" + parsed.size());
         logService.log(user, "上传文件 " + uf.getFileName(), "records=" + parsed.size());
         return result;
     }

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -498,7 +498,7 @@ public class WorkRecordController {
         logContext.setModule("工时记录");
         logContext.setEntity("WorkRecord", id != null ? id.toString() : null);
         logContext.setSummary("更新记录");
-        logContext.appendDetail("drawing=" + saved.getDrawingNumber());
+        logContext.appendDetail("drawing=" + updated.getDrawingNumber());
         logService.log(user, "更新记录 " + id, null);
         return updated;
     }

--- a/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkRecordController.java
@@ -615,9 +615,7 @@ public class WorkRecordController {
         result.put("total", parsed.size());
         result.put("codeMissing", codeMissing);
         result.put("hoursMissing", hoursMissing);
-        if (!store) {
-            result.put("records", parsed);
-        }
+        result.put("records", parsed);
         logService.log(user, "上传文件 " + uf.getFileName(), "records=" + parsed.size());
         return result;
     }

--- a/backend/src/main/java/com/example/worktime/controller/WorkerController.java
+++ b/backend/src/main/java/com/example/worktime/controller/WorkerController.java
@@ -2,6 +2,7 @@ package com.example.worktime.controller;
 
 import com.example.worktime.model.Worker;
 import com.example.worktime.repository.WorkerRepository;
+import com.example.worktime.service.OperationLogContext;
 import com.example.worktime.service.OperationLogService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -15,10 +16,12 @@ import java.util.List;
 public class WorkerController {
     private final WorkerRepository repository;
     private final OperationLogService logService;
+    private final OperationLogContext logContext;
 
-    public WorkerController(WorkerRepository repository, OperationLogService logService) {
+    public WorkerController(WorkerRepository repository, OperationLogService logService, OperationLogContext logContext) {
         this.repository = repository;
         this.logService = logService;
+        this.logContext = logContext;
     }
 
     @GetMapping
@@ -46,6 +49,10 @@ public class WorkerController {
     public Worker create(@RequestBody Worker worker, @RequestHeader("X-User") String user) {
         validate(worker);
         Worker saved = repository.save(worker);
+        logContext.setModule("人员管理");
+        logContext.setEntity("Worker", saved.getId() != null ? saved.getId().toString() : null);
+        logContext.setSummary("新增人员");
+        logContext.appendDetail("name=" + worker.getName());
         logService.log(user, "新增人员 " + worker.getName(), "id=" + saved.getId());
         return saved;
     }
@@ -55,6 +62,10 @@ public class WorkerController {
         worker.setId(id);
         validate(worker);
         Worker saved = repository.save(worker);
+        logContext.setModule("人员管理");
+        logContext.setEntity("Worker", id != null ? id.toString() : null);
+        logContext.setSummary("更新人员");
+        logContext.appendDetail("name=" + worker.getName());
         logService.log(user, "更新人员 " + id, null);
         return saved;
     }
@@ -62,6 +73,9 @@ public class WorkerController {
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id, @RequestHeader("X-User") String user) {
         repository.deleteById(id);
+        logContext.setModule("人员管理");
+        logContext.setEntity("Worker", id != null ? id.toString() : null);
+        logContext.setSummary("删除人员");
         logService.log(user, "删除人员 " + id, null);
     }
 

--- a/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
+++ b/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
@@ -24,15 +24,47 @@ public class OperationLogFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String user = request.getHeader("X-User");
+        long start = System.currentTimeMillis();
         filterChain.doFilter(request, response);
         if (user != null && request.getAttribute("operationLogged") == null
                 && !request.getRequestURI().startsWith("/api/logs")) {
             OperationLog log = new OperationLog();
             log.setUsername(user);
             String path = request.getRequestURI().replaceFirst("^/api", "");
-            log.setAction(request.getMethod() + " " + path);
+            String query = request.getQueryString();
+            String action = request.getMethod() + " " + path + (query != null ? "?" + query : "");
+            log.setAction(action);
             log.setTimestamp(LocalDateTime.now());
+            log.setDetails(buildDetails(request, response, start));
             repository.save(log);
         }
+    }
+
+    private String buildDetails(HttpServletRequest request, HttpServletResponse response, long start) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Status: ").append(response.getStatus()).append('\n');
+        builder.append("Duration: ").append(System.currentTimeMillis() - start).append(" ms\n");
+        String client = request.getHeader("X-Forwarded-For");
+        if (client == null || client.isBlank()) {
+            client = request.getRemoteAddr();
+        }
+        if (client != null) {
+            builder.append("Client: ").append(client).append('\n');
+        }
+        String userAgent = request.getHeader("User-Agent");
+        if (userAgent != null && !userAgent.isBlank()) {
+            builder.append("User-Agent: ").append(userAgent).append('\n');
+        }
+        if (!request.getParameterMap().isEmpty()) {
+            builder.append("Parameters:\n");
+            request.getParameterMap().forEach((key, values) -> {
+                builder.append("  ").append(key).append("=");
+                if (values != null) {
+                    builder.append(String.join(",", values));
+                }
+                builder.append('\n');
+            });
+        }
+        return builder.toString().trim();
     }
 }

--- a/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
+++ b/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
@@ -2,6 +2,7 @@ package com.example.worktime.filter;
 
 import com.example.worktime.model.OperationLog;
 import com.example.worktime.repository.OperationLogRepository;
+import com.example.worktime.service.OperationLogContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -10,46 +11,91 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Component
 public class OperationLogFilter extends OncePerRequestFilter {
     private final OperationLogRepository repository;
+    private final OperationLogContext context;
 
-    public OperationLogFilter(OperationLogRepository repository) {
+    public OperationLogFilter(OperationLogRepository repository, OperationLogContext context) {
         this.repository = repository;
+        this.context = context;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String user = request.getHeader("X-User");
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+        context.reset();
+        String user = wrappedRequest.getHeader("X-User");
         long start = System.currentTimeMillis();
-        filterChain.doFilter(request, response);
-        if (user != null && request.getAttribute("operationLogged") == null
-                && !request.getRequestURI().startsWith("/api/logs")) {
-            OperationLog log = new OperationLog();
-            log.setUsername(user);
-            String path = request.getRequestURI().replaceFirst("^/api", "");
-            String query = request.getQueryString();
-            String action = request.getMethod() + " " + path + (query != null ? "?" + query : "");
-            log.setAction(action);
-            log.setTimestamp(LocalDateTime.now());
-            log.setDetails(buildDetails(request, response, start));
-            repository.save(log);
+        String traceId = resolveTraceId(wrappedRequest);
+        context.setTraceId(traceId);
+        try {
+            filterChain.doFilter(wrappedRequest, wrappedResponse);
+        } finally {
+            try {
+                if (user != null && wrappedRequest.getAttribute("operationLogged") == null
+                        && !wrappedRequest.getRequestURI().startsWith("/api/logs")) {
+                    OperationLog log = new OperationLog();
+                    log.setUsername(user);
+                    log.setTimestamp(LocalDateTime.now());
+                    log.setTraceId(traceId);
+                    String path = wrappedRequest.getRequestURI().replaceFirst("^/api", "");
+                    String query = wrappedRequest.getQueryString();
+                    log.setPath(path);
+                    log.setQuery(query);
+                    log.setMethod(wrappedRequest.getMethod());
+                    String action = wrappedRequest.getMethod() + " " + path + (query != null ? "?" + query : "");
+                    log.setAction(action);
+                    log.setStatusCode(wrappedResponse.getStatus());
+                    long duration = System.currentTimeMillis() - start;
+                    log.setDurationMs(duration);
+                    log.setClientIp(resolveClientIp(wrappedRequest));
+                    log.setUserAgent(wrappedRequest.getHeader("User-Agent"));
+                    log.setDetails(buildDetails(wrappedRequest, wrappedResponse, duration));
+                    context.apply(log);
+                    repository.save(log);
+                }
+            } finally {
+                wrappedResponse.copyBodyToResponse();
+                context.reset();
+            }
         }
     }
 
-    private String buildDetails(HttpServletRequest request, HttpServletResponse response, long start) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("Status: ").append(response.getStatus()).append('\n');
-        builder.append("Duration: ").append(System.currentTimeMillis() - start).append(" ms\n");
+    private String resolveTraceId(HttpServletRequest request) {
+        String header = request.getHeader("X-Trace-Id");
+        if (StringUtils.hasText(header)) {
+            return header.trim();
+        }
+        return UUID.randomUUID().toString();
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
         String client = request.getHeader("X-Forwarded-For");
         if (!StringUtils.hasText(client)) {
             client = request.getRemoteAddr();
         }
-        if (client != null) {
+        if (client != null && client.contains(",")) {
+            return client.split(",", 2)[0].trim();
+        }
+        return client;
+    }
+
+    private String buildDetails(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response, long duration) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Status: ").append(response.getStatus()).append('\n');
+        builder.append("Duration: ").append(duration).append(" ms\n");
+        String client = resolveClientIp(request);
+        if (StringUtils.hasText(client)) {
             builder.append("Client: ").append(client).append('\n');
         }
         String userAgent = request.getHeader("User-Agent");
@@ -66,6 +112,27 @@ public class OperationLogFilter extends OncePerRequestFilter {
                 builder.append('\n');
             });
         }
+        String requestBody = toBodyString(request.getContentAsByteArray(), request.getCharacterEncoding());
+        if (StringUtils.hasText(requestBody)) {
+            builder.append("Request Body:\n").append(requestBody).append('\n');
+        }
+        String responseBody = toBodyString(response.getContentAsByteArray(), response.getCharacterEncoding());
+        if (StringUtils.hasText(responseBody)) {
+            builder.append("Response Body:\n").append(responseBody).append('\n');
+        }
         return builder.toString().trim();
+    }
+
+    private String toBodyString(byte[] buf, String encoding) {
+        if (buf == null || buf.length == 0) {
+            return null;
+        }
+        int max = Math.min(buf.length, 2048);
+        Charset charset = Charset.forName(encoding != null ? encoding : "UTF-8");
+        String body = new String(buf, 0, max, charset);
+        if (buf.length > max) {
+            body += "\n...(truncated)";
+        }
+        return body.trim();
     }
 }

--- a/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
+++ b/backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java
@@ -3,6 +3,7 @@ package com.example.worktime.filter;
 import com.example.worktime.model.OperationLog;
 import com.example.worktime.repository.OperationLogRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -45,14 +46,14 @@ public class OperationLogFilter extends OncePerRequestFilter {
         builder.append("Status: ").append(response.getStatus()).append('\n');
         builder.append("Duration: ").append(System.currentTimeMillis() - start).append(" ms\n");
         String client = request.getHeader("X-Forwarded-For");
-        if (client == null || client.isBlank()) {
+        if (!StringUtils.hasText(client)) {
             client = request.getRemoteAddr();
         }
         if (client != null) {
             builder.append("Client: ").append(client).append('\n');
         }
         String userAgent = request.getHeader("User-Agent");
-        if (userAgent != null && !userAgent.isBlank()) {
+        if (StringUtils.hasText(userAgent)) {
             builder.append("User-Agent: ").append(userAgent).append('\n');
         }
         if (!request.getParameterMap().isEmpty()) {

--- a/backend/src/main/java/com/example/worktime/model/OperationLog.java
+++ b/backend/src/main/java/com/example/worktime/model/OperationLog.java
@@ -18,6 +18,30 @@ public class OperationLog {
 
     private LocalDateTime timestamp;
 
+    private String summary;
+
+    private String module;
+
+    private String entityType;
+
+    private String entityId;
+
+    private Integer statusCode;
+
+    private Long durationMs;
+
+    private String clientIp;
+
+    private String userAgent;
+
+    private String method;
+
+    private String path;
+
+    private String query;
+
+    private String traceId;
+
     @Lob
     private String details;
 
@@ -32,6 +56,42 @@ public class OperationLog {
 
     public LocalDateTime getTimestamp() { return timestamp; }
     public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+
+    public String getSummary() { return summary; }
+    public void setSummary(String summary) { this.summary = summary; }
+
+    public String getModule() { return module; }
+    public void setModule(String module) { this.module = module; }
+
+    public String getEntityType() { return entityType; }
+    public void setEntityType(String entityType) { this.entityType = entityType; }
+
+    public String getEntityId() { return entityId; }
+    public void setEntityId(String entityId) { this.entityId = entityId; }
+
+    public Integer getStatusCode() { return statusCode; }
+    public void setStatusCode(Integer statusCode) { this.statusCode = statusCode; }
+
+    public Long getDurationMs() { return durationMs; }
+    public void setDurationMs(Long durationMs) { this.durationMs = durationMs; }
+
+    public String getClientIp() { return clientIp; }
+    public void setClientIp(String clientIp) { this.clientIp = clientIp; }
+
+    public String getUserAgent() { return userAgent; }
+    public void setUserAgent(String userAgent) { this.userAgent = userAgent; }
+
+    public String getMethod() { return method; }
+    public void setMethod(String method) { this.method = method; }
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getQuery() { return query; }
+    public void setQuery(String query) { this.query = query; }
+
+    public String getTraceId() { return traceId; }
+    public void setTraceId(String traceId) { this.traceId = traceId; }
 
     public String getDetails() { return details; }
     public void setDetails(String details) { this.details = details; }

--- a/backend/src/main/java/com/example/worktime/repository/OperationLogRepository.java
+++ b/backend/src/main/java/com/example/worktime/repository/OperationLogRepository.java
@@ -2,10 +2,11 @@ package com.example.worktime.repository;
 
 import com.example.worktime.model.OperationLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 
-public interface OperationLogRepository extends JpaRepository<OperationLog, Long> {
+public interface OperationLogRepository extends JpaRepository<OperationLog, Long>, JpaSpecificationExecutor<OperationLog> {
     List<OperationLog> findByUsernameOrderByTimestampDesc(String username);
     List<OperationLog> findAllByOrderByTimestampDesc();
 }

--- a/backend/src/main/java/com/example/worktime/service/OperationLogContext.java
+++ b/backend/src/main/java/com/example/worktime/service/OperationLogContext.java
@@ -1,0 +1,109 @@
+package com.example.worktime.service;
+
+import com.example.worktime.model.OperationLog;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Thread-local context object used to enrich automatically captured operation logs.
+ */
+@Component
+public class OperationLogContext {
+    private static final ThreadLocal<ContextState> STATE = ThreadLocal.withInitial(ContextState::new);
+
+    public void reset() {
+        STATE.remove();
+    }
+
+    private ContextState state() {
+        return STATE.get();
+    }
+
+    public void setModule(String module) {
+        state().module = normalize(module);
+    }
+
+    public void setEntity(String type, String id) {
+        state().entityType = normalize(type);
+        state().entityId = normalize(id);
+    }
+
+    public void setSummary(String summary) {
+        state().summary = normalize(summary);
+    }
+
+    public void setTraceId(String traceId) {
+        state().traceId = normalize(traceId);
+    }
+
+    public String getTraceId() {
+        ContextState s = state();
+        if (!StringUtils.hasText(s.traceId)) {
+            return null;
+        }
+        return s.traceId;
+    }
+
+    public void appendDetail(String detail) {
+        if (!StringUtils.hasText(detail)) {
+            return;
+        }
+        state().details.add(detail.trim());
+    }
+
+    public void apply(OperationLog log) {
+        ContextState snapshot = state().copy();
+        if (StringUtils.hasText(snapshot.module)) {
+            log.setModule(snapshot.module);
+        }
+        if (StringUtils.hasText(snapshot.summary) && !StringUtils.hasText(log.getSummary())) {
+            log.setSummary(snapshot.summary);
+        }
+        if (StringUtils.hasText(snapshot.entityType)) {
+            log.setEntityType(snapshot.entityType);
+        }
+        if (StringUtils.hasText(snapshot.entityId)) {
+            log.setEntityId(snapshot.entityId);
+        }
+        if (StringUtils.hasText(snapshot.traceId) && !StringUtils.hasText(log.getTraceId())) {
+            log.setTraceId(snapshot.traceId);
+        }
+        if (!snapshot.details.isEmpty()) {
+            String existing = log.getDetails();
+            String appended = String.join("\n", snapshot.details);
+            if (StringUtils.hasText(existing)) {
+                log.setDetails(existing + "\n" + appended);
+            } else {
+                log.setDetails(appended);
+            }
+        }
+    }
+
+    private String normalize(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private static class ContextState {
+        private String module;
+        private String entityType;
+        private String entityId;
+        private String summary;
+        private String traceId;
+        private List<String> details = new ArrayList<>();
+
+        ContextState copy() {
+            ContextState copy = new ContextState();
+            copy.module = this.module;
+            copy.entityType = this.entityType;
+            copy.entityId = this.entityId;
+            copy.summary = this.summary;
+            copy.traceId = this.traceId;
+            copy.details = new ArrayList<>(this.details);
+            return copy;
+        }
+    }
+}
+

--- a/backend/src/main/java/com/example/worktime/service/OperationLogService.java
+++ b/backend/src/main/java/com/example/worktime/service/OperationLogService.java
@@ -3,6 +3,7 @@ package com.example.worktime.service;
 import com.example.worktime.model.OperationLog;
 import com.example.worktime.repository.OperationLogRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -12,9 +13,11 @@ import java.time.LocalDateTime;
 @Service
 public class OperationLogService {
     private final OperationLogRepository repository;
+    private final OperationLogContext context;
 
-    public OperationLogService(OperationLogRepository repository) {
+    public OperationLogService(OperationLogRepository repository, OperationLogContext context) {
         this.repository = repository;
+        this.context = context;
     }
 
     public void log(String username, String action, String details) {
@@ -22,13 +25,17 @@ public class OperationLogService {
         OperationLog log = new OperationLog();
         log.setUsername(username);
         log.setAction(action);
-        log.setDetails(details);
+        if (StringUtils.hasText(details)) {
+            log.setDetails(details);
+        }
         log.setTimestamp(LocalDateTime.now());
+        context.apply(log);
         repository.save(log);
         ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
         if (attrs != null) {
             HttpServletRequest req = attrs.getRequest();
             if (req != null) req.setAttribute("operationLogged", true);
         }
+        context.reset();
     }
 }

--- a/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
+++ b/backend/src/main/java/com/example/worktime/service/ProcessCodeService.java
@@ -21,6 +21,7 @@ public class ProcessCodeService {
 
     private final ProcessCodeRepository repository;
     private final ConcurrentHashMap<String, String> cache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Boolean> codeIndex = new ConcurrentHashMap<>();
 
     public ProcessCodeService(ProcessCodeRepository repository) {
         this.repository = repository;
@@ -43,6 +44,7 @@ public class ProcessCodeService {
                 continue;
             }
             cache.put(name, code);
+            indexCode(code);
             snapshot.put(name, code);
         }
         return snapshot;
@@ -58,6 +60,7 @@ public class ProcessCodeService {
         if (name.isEmpty()) return null;
         String existing = cache.get(name);
         if (existing != null) {
+            indexCode(existing);
             return existing;
         }
         ProcessCode pc = repository.findByName(name);
@@ -65,6 +68,7 @@ public class ProcessCodeService {
             String code = pc.getCode().trim();
             if (!code.isEmpty()) {
                 cache.put(name, code);
+                indexCode(code);
                 return code;
             }
         }
@@ -104,10 +108,35 @@ public class ProcessCodeService {
                     continue;
                 }
                 cache.put(name, code);
+                indexCode(code);
                 result.put(name, code);
             }
         }
         return result;
+    }
+
+    public boolean isKnownCode(String code) {
+        if (code == null) {
+            return false;
+        }
+        String trimmed = code.trim();
+        if (trimmed.isEmpty()) {
+            return false;
+        }
+        Boolean cached = codeIndex.get(trimmed);
+        if (cached != null) {
+            return cached;
+        }
+        ProcessCode pc = repository.findByCode(trimmed);
+        boolean known = pc != null && pc.getCode() != null && !pc.getCode().trim().isEmpty();
+        codeIndex.put(trimmed, known);
+        if (known && pc.getName() != null) {
+            String name = pc.getName().trim();
+            if (!name.isEmpty() && pc.getCode() != null) {
+                cache.putIfAbsent(name, pc.getCode().trim());
+            }
+        }
+        return known;
     }
 
     public ProcessCode rememberMapping(String name, String code) {
@@ -138,9 +167,21 @@ public class ProcessCodeService {
         }
         ProcessCode saved = repository.save(target);
         cache.put(trimmedName, trimmedCode);
+        indexCode(trimmedCode);
         if (!created && saved.getName() != null && !saved.getName().trim().isEmpty()) {
             cache.put(saved.getName().trim(), trimmedCode);
         }
         return saved;
+    }
+
+    private void indexCode(String code) {
+        if (code == null) {
+            return;
+        }
+        String trimmed = code.trim();
+        if (trimmed.isEmpty()) {
+            return;
+        }
+        codeIndex.put(trimmed, Boolean.TRUE);
     }
 }

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -84,5 +84,17 @@ CREATE TABLE IF NOT EXISTS operation_log (
     username VARCHAR(255),
     action VARCHAR(255),
     timestamp DATETIME,
+    summary VARCHAR(255),
+    module VARCHAR(255),
+    entity_type VARCHAR(255),
+    entity_id VARCHAR(255),
+    status_code INT,
+    duration_ms BIGINT,
+    client_ip VARCHAR(255),
+    user_agent VARCHAR(512),
+    method VARCHAR(32),
+    path VARCHAR(255),
+    query VARCHAR(512),
+    trace_id VARCHAR(64),
     details TEXT
 );

--- a/docs/UserManual.zh-CN.md
+++ b/docs/UserManual.zh-CN.md
@@ -1,0 +1,55 @@
+# 工时管理系统使用手册
+
+## 1. 登录与主界面导航
+- 打开系统后首先进入登录页，填写用户名与密码并点击“登录”，表单会在提交时禁止重复点击并在失败时展示服务端返回的错误信息，登录成功后会把登录状态与用户名写入浏览器本地存储。登录成功会触发父组件切换到主界面。【F:frontend/src/components/LoginPage.vue†L1-L65】
+- 登录后顶部导航条提供 Excel 上传、扫码录入、人员管理、工序代码和操作记录五个功能入口，右侧的“退出登录”会清理本地存储并返回登录页。主容器通过 `<router-view>` 承载各业务页面，并在子页面保存成功时触发刷新。【F:frontend/src/App.vue†L1-L52】
+
+## 2. Excel 上传与预览
+- “Excel 上传”页顶部可选择本地文件进行解析，也可以从下拉框加载历史文件或删除文件，提供“清除0工序”“保存”“打印”等批量操作按钮，并在解析大文件时显示进度条反馈。【F:frontend/src/components/RecordUpload.vue†L4-L24】【F:frontend/src/components/RecordUpload.vue†L171-L178】
+- 解析接口会将 Excel 转换后的记录分批写入数据库并返回对应的文件 ID、缺陷统计和记录列表，保证预览的每一行都已经持久化；上传记录同时会生成 `UploadedFile` 记录并在服务端统计缺少工序代码/工时的行数。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L587-L650】
+- 历史文件加载后会按图号分组渲染，支持快速跳页、图号搜索和“清除0工序”过滤；加载时会调用缺陷检测并为每条记录构建分页结构。【F:frontend/src/components/RecordUpload.vue†L34-L168】【F:frontend/src/components/RecordUpload.vue†L528-L555】
+- 表格内可直接编辑计划数、单件工时、工序代码/名称等字段，行会根据缺失字段标红并展示缺陷摘要；缺陷检测会同步维护“缺少通知单号/工序代码/条形码”等状态以提示补录项。【F:frontend/src/components/RecordUpload.vue†L90-L157】【F:frontend/src/components/RecordUpload.vue†L439-L488】
+- 任何单元格修改都会触发自动保存，组件会构造精简载荷调用 `/api/workrecords/autosave`，并在服务端补齐条码、补录标记与缺陷状态后回写最新字段值，避免重复提交或丢失修改。【F:frontend/src/components/RecordUpload.vue†L705-L793】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L409-L478】
+- 点击“保存”会筛出已填写工序代码和条形码的记录，按 1000 条分批提交给后端，后端根据条码去重标记补录状态并写库；保存完成后会刷新文件列表并发出提示。【F:frontend/src/components/RecordUpload.vue†L631-L665】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L549-L585】
+- “打印”按钮会预先加载全部条形码，将所有分页渲染到 DOM 后调用 `window.print()`，同时配合打印样式把页脚显示成“图号：XXX”，对齐 A4 页边距并在页面底部左侧覆盖浏览器默认 URL。【F:frontend/src/components/RecordUpload.vue†L666-L687】【F:frontend/src/components/RecordUpload.vue†L753-L757】【F:frontend/src/assets/style.css†L325-L368】
+
+## 3. 缺陷追踪与批量处理
+- 左侧“缺陷追踪”面板会将所有缺陷按照图号与缺陷类型聚合，显示每组缺陷数量，点击可在主表格中过滤出对应行，也可以一键退出筛选。【F:frontend/src/components/RecordUpload.vue†L25-L55】【F:frontend/src/components/RecordUpload.vue†L309-L338】【F:frontend/src/components/RecordIssuePanel.vue†L1-L48】
+- 针对缺少工序代码、工序名称、单件工时、计划数的缺陷，可通过“批量填写”打开模态框，集中输入并一次性应用到所有筛选行，便于快速补齐数据。【F:frontend/src/components/RecordIssuePanel.vue†L13-L38】【F:frontend/src/components/BulkIssueModal.vue†L1-L81】
+- 服务端在解析、加载和保存时会调用 `flagIssues`，对通知单号、产品、工序、工时、条形码等字段逐项检查，并把“仅填写了工序名称或 0 的工序代码”视为缺失，同时清除无效条码，确保缺陷面板与持久化状态保持一致。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L671-L734】
+
+## 4. 打印版式与图号页脚
+- 打印专用样式在 `@media print` 中启用，取消左右外边距、禁止分页内断行，并为每页底部预留 36px 的空间，用绝对定位的 `.print-page-footer` 显示“图号：XXX”，颜色置灰以模拟打印脚注。【F:frontend/src/assets/style.css†L325-L348】
+- 页脚文本来自 `formatPrintFooter`，会先对图号做字符清洗，确保在缺省图号时仍然输出“图号：（空）”，避免打印空白或出现非法字符。【F:frontend/src/components/RecordUpload.vue†L753-L757】
+
+## 5. 扫码录入与补录
+- “扫码录入”页支持直接输入/扫码条形码查询，也可加载某个文件的已填记录；工具栏还提供按自然月或图号导出 Excel 的功能键。【F:frontend/src/components/RecordScanner.vue†L3-L47】
+- 表格列出了计划数、人员分配、起止日期、合格数等字段，支持在非只读模式下就地编辑并实时计算工时小计、分配值，必要时可新增行或删除行。【F:frontend/src/components/RecordScanner.vue†L49-L160】
+- 查询或加载记录时会调用 `processRecords`，对每条数据执行补充（例如拆分人员代码、回填班组、计算合计），并在需要时访问人员库补足姓名信息。【F:frontend/src/components/RecordScanner.vue†L205-L355】
+- “保存”“保存全部”“删除”“复制”均走后台接口：单条更新使用 `PUT /api/workrecords/{id}`，批量保存用 `PUT /api/workrecords/bulk`，复制行调用 `/api/workrecords/duplicate/{id}`；保存前会校验数量与工时分配并提示缺失字段。【F:frontend/src/components/RecordScanner.vue†L275-L334】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L376-L535】
+- 导出功能对应 `/api/workrecords/natural-month/{year}/{month}/export` 与 `/api/workrecords/drawing/{drawing}/export`，后端会自动根据自然月（26 日跨月）或图号筛选记录并生成 Excel。【F:frontend/src/components/RecordScanner.vue†L228-L255】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L135-L185】
+
+## 6. 人员管理
+- 人员列表支持按工号/姓名搜索、在线编辑字段以及一键保存或删除；“新增人员”按钮会弹出模态框，自动聚焦工号输入并锁定页面滚动，表单仅在工号、姓名填写后允许提交。【F:frontend/src/components/WorkerManager.vue†L1-L150】
+- 后端提供 `/api/workers` 及 `/api/workers/search` 查询接口，新增/更新时会校验工号与姓名必填，并把操作记录到日志中。【F:backend/src/main/java/com/example/worktime/controller/WorkerController.java†L17-L73】【F:backend/src/main/java/com/example/worktime/controller/WorkerController.java†L74-L107】
+
+## 7. 工序代码管理
+- 页面结构与人员管理类似，可按代号或名称搜索，支持在线编辑大类、内容等字段，并通过模态框新增工序代码，内置冲突提示以便发现重复代号。【F:frontend/src/components/ProcessManager.vue†L1-L188】
+- 服务端在新增或更新时会确保代号、名称非空且全局唯一，`ProcessCodeService` 会缓存名称到代号的映射，并建立代号索引供缺陷检测和自动补全使用；`/api/processcodes/remember` 还允许从上传页直接记忆名称-代号配对。【F:backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java†L17-L118】【F:backend/src/main/java/com/example/worktime/service/ProcessCodeService.java†L19-L120】【F:backend/src/main/java/com/example/worktime/service/ProcessCodeService.java†L121-L205】
+
+## 8. 操作记录中心
+- 操作记录页提供用户、关键字、日期范围、模块、实体类型/ID、客户端 IP、Trace ID、状态码及耗时区间等筛选项，支持修改每页条数、重置、手动刷新及自动每分钟刷新。【F:frontend/src/components/OperationLog.vue†L3-L135】
+- 列表点击可展开详情查看请求方式、路径、实体标识及响应详情，支持复制到剪贴板；相同 Trace ID 的记录会自动分组展示主从关系，便于追踪批量操作。【F:frontend/src/components/OperationLog.vue†L96-L133】【F:frontend/src/components/OperationLog.vue†L220-L236】【F:frontend/src/components/OperationLog.vue†L305-L332】
+- 后端分页接口 `/api/logs` 支持上述筛选条件，所有条件都会在查询时构建 JPA Specification；过滤器会在每次请求时记录用户名、模块、摘要、状态码、耗时、客户端、请求/响应体，并附带 Trace ID 与线程上下文中收集到的业务实体信息。【F:backend/src/main/java/com/example/worktime/controller/OperationLogController.java†L27-L90】【F:backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java†L24-L87】【F:backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java†L88-L147】
+- 业务代码在执行时可通过 `OperationLogContext` 注入模块、实体、摘要和补充详情，配合 `OperationLogService.log` 写入数据库并阻止重复记录，保证日志详情清晰完整。【F:backend/src/main/java/com/example/worktime/service/OperationLogContext.java†L13-L71】【F:backend/src/main/java/com/example/worktime/service/OperationLogService.java†L17-L36】
+
+## 9. 上传文件管理
+- 历史文件下拉列表来自 `/api/files` 接口，它会连同记录数量一起返回；删除文件时会级联清除关联工时记录，并把文件名、删除数量写入操作日志。【F:backend/src/main/java/com/example/worktime/controller/UploadedFileController.java†L30-L48】
+- 上传接口允许保留原始 Excel 数据（`store` 参数默认为 true），方便后续下载或审计；文件 ID 会回传给前端用于再次加载或打印。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L587-L644】
+
+## 10. 条形码与补录规则
+- 系统提供 `/api/workrecords/generateBarcode(s)` 接口生成 Code128 条码图片，上传与自动保存时会对条码进行 Unicode 归一化与空白清理，并在缺少工序代码时自动清空条码，防止错误数据混入。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L350-L374】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L450-L734】
+- 保存或自动保存时若检测到条码在其它记录中已存在，会把该条目标记为补录（supplemental），方便后续统计与打印时区分。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L450-L573】
+
+## 11. 业务日志与回溯
+- 所有与工时记录、人员、工序、文件相关的新增/修改/删除操作都会在对应控制器内设置模块、实体 ID 与摘要，并借助过滤器追加状态码、耗时、请求体，方便在操作记录中按图号、Trace ID 或实体快速回溯业务动作。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L470-L584】【F:backend/src/main/java/com/example/worktime/controller/WorkerController.java†L74-L107】【F:backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java†L62-L118】【F:backend/src/main/java/com/example/worktime/controller/UploadedFileController.java†L35-L48】【F:backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java†L24-L147】

--- a/docs/UserManual.zh-CN.md
+++ b/docs/UserManual.zh-CN.md
@@ -1,55 +1,153 @@
-# 工时管理系统使用手册
+# 工时管理系统使用手册（适用于一线工作人员）
 
-## 1. 登录与主界面导航
-- 打开系统后首先进入登录页，填写用户名与密码并点击“登录”，表单会在提交时禁止重复点击并在失败时展示服务端返回的错误信息，登录成功后会把登录状态与用户名写入浏览器本地存储。登录成功会触发父组件切换到主界面。【F:frontend/src/components/LoginPage.vue†L1-L65】
-- 登录后顶部导航条提供 Excel 上传、扫码录入、人员管理、工序代码和操作记录五个功能入口，右侧的“退出登录”会清理本地存储并返回登录页。主容器通过 `<router-view>` 承载各业务页面，并在子页面保存成功时触发刷新。【F:frontend/src/App.vue†L1-L52】
+本手册面向日常录入、核对与打印工时数据的工作人员，按照实际操作流程详细说明系统中的常用功能。阅读后可独立完成数据导入、缺陷排查、打印、扫码补录以及人员与工序信息维护等工作。
 
-## 2. Excel 上传与预览
-- “Excel 上传”页顶部可选择本地文件进行解析，也可以从下拉框加载历史文件或删除文件，提供“清除0工序”“保存”“打印”等批量操作按钮，并在解析大文件时显示进度条反馈。【F:frontend/src/components/RecordUpload.vue†L4-L24】【F:frontend/src/components/RecordUpload.vue†L171-L178】
-- 解析接口会将 Excel 转换后的记录分批写入数据库并返回对应的文件 ID、缺陷统计和记录列表，保证预览的每一行都已经持久化；上传记录同时会生成 `UploadedFile` 记录并在服务端统计缺少工序代码/工时的行数。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L587-L650】
-- 历史文件加载后会按图号分组渲染，支持快速跳页、图号搜索和“清除0工序”过滤；加载时会调用缺陷检测并为每条记录构建分页结构。【F:frontend/src/components/RecordUpload.vue†L34-L168】【F:frontend/src/components/RecordUpload.vue†L528-L555】
-- 表格内可直接编辑计划数、单件工时、工序代码/名称等字段，行会根据缺失字段标红并展示缺陷摘要；缺陷检测会同步维护“缺少通知单号/工序代码/条形码”等状态以提示补录项。【F:frontend/src/components/RecordUpload.vue†L90-L157】【F:frontend/src/components/RecordUpload.vue†L439-L488】
-- 任何单元格修改都会触发自动保存，组件会构造精简载荷调用 `/api/workrecords/autosave`，并在服务端补齐条码、补录标记与缺陷状态后回写最新字段值，避免重复提交或丢失修改。【F:frontend/src/components/RecordUpload.vue†L705-L793】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L409-L478】
-- 点击“保存”会筛出已填写工序代码和条形码的记录，按 1000 条分批提交给后端，后端根据条码去重标记补录状态并写库；保存完成后会刷新文件列表并发出提示。【F:frontend/src/components/RecordUpload.vue†L631-L665】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L549-L585】
-- “打印”按钮会预先加载全部条形码，将所有分页渲染到 DOM 后调用 `window.print()`，同时配合打印样式把页脚显示成“图号：XXX”，对齐 A4 页边距并在页面底部左侧覆盖浏览器默认 URL。【F:frontend/src/components/RecordUpload.vue†L666-L687】【F:frontend/src/components/RecordUpload.vue†L753-L757】【F:frontend/src/assets/style.css†L325-L368】
+---
 
-## 3. 缺陷追踪与批量处理
-- 左侧“缺陷追踪”面板会将所有缺陷按照图号与缺陷类型聚合，显示每组缺陷数量，点击可在主表格中过滤出对应行，也可以一键退出筛选。【F:frontend/src/components/RecordUpload.vue†L25-L55】【F:frontend/src/components/RecordUpload.vue†L309-L338】【F:frontend/src/components/RecordIssuePanel.vue†L1-L48】
-- 针对缺少工序代码、工序名称、单件工时、计划数的缺陷，可通过“批量填写”打开模态框，集中输入并一次性应用到所有筛选行，便于快速补齐数据。【F:frontend/src/components/RecordIssuePanel.vue†L13-L38】【F:frontend/src/components/BulkIssueModal.vue†L1-L81】
-- 服务端在解析、加载和保存时会调用 `flagIssues`，对通知单号、产品、工序、工时、条形码等字段逐项检查，并把“仅填写了工序名称或 0 的工序代码”视为缺失，同时清除无效条码，确保缺陷面板与持久化状态保持一致。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L671-L734】
+## 1. 登录系统
+1. 打开浏览器访问系统网址，进入登录页面。
+2. 在“用户名”“密码”输入框中填写账号信息。
+3. 检查键盘大小写是否正确，确认无误后点击 **“登录”**。
+4. 登录成功后会自动跳转到主界面，右上角显示当前用户名。
+5. 需要离开电脑或交接班时，点击右上角 **“退出登录”**，以免账号被他人使用。
 
-## 4. 打印版式与图号页脚
-- 打印专用样式在 `@media print` 中启用，取消左右外边距、禁止分页内断行，并为每页底部预留 36px 的空间，用绝对定位的 `.print-page-footer` 显示“图号：XXX”，颜色置灰以模拟打印脚注。【F:frontend/src/assets/style.css†L325-L348】
-- 页脚文本来自 `formatPrintFooter`，会先对图号做字符清洗，确保在缺省图号时仍然输出“图号：（空）”，避免打印空白或出现非法字符。【F:frontend/src/components/RecordUpload.vue†L753-L757】
+> **提示**：如果密码输错，系统会在登录框下方给出提示信息；连续多次失败，请联系管理员重置密码。
 
-## 5. 扫码录入与补录
-- “扫码录入”页支持直接输入/扫码条形码查询，也可加载某个文件的已填记录；工具栏还提供按自然月或图号导出 Excel 的功能键。【F:frontend/src/components/RecordScanner.vue†L3-L47】
-- 表格列出了计划数、人员分配、起止日期、合格数等字段，支持在非只读模式下就地编辑并实时计算工时小计、分配值，必要时可新增行或删除行。【F:frontend/src/components/RecordScanner.vue†L49-L160】
-- 查询或加载记录时会调用 `processRecords`，对每条数据执行补充（例如拆分人员代码、回填班组、计算合计），并在需要时访问人员库补足姓名信息。【F:frontend/src/components/RecordScanner.vue†L205-L355】
-- “保存”“保存全部”“删除”“复制”均走后台接口：单条更新使用 `PUT /api/workrecords/{id}`，批量保存用 `PUT /api/workrecords/bulk`，复制行调用 `/api/workrecords/duplicate/{id}`；保存前会校验数量与工时分配并提示缺失字段。【F:frontend/src/components/RecordScanner.vue†L275-L334】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L376-L535】
-- 导出功能对应 `/api/workrecords/natural-month/{year}/{month}/export` 与 `/api/workrecords/drawing/{drawing}/export`，后端会自动根据自然月（26 日跨月）或图号筛选记录并生成 Excel。【F:frontend/src/components/RecordScanner.vue†L228-L255】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L135-L185】
+---
 
-## 6. 人员管理
-- 人员列表支持按工号/姓名搜索、在线编辑字段以及一键保存或删除；“新增人员”按钮会弹出模态框，自动聚焦工号输入并锁定页面滚动，表单仅在工号、姓名填写后允许提交。【F:frontend/src/components/WorkerManager.vue†L1-L150】
-- 后端提供 `/api/workers` 及 `/api/workers/search` 查询接口，新增/更新时会校验工号与姓名必填，并把操作记录到日志中。【F:backend/src/main/java/com/example/worktime/controller/WorkerController.java†L17-L73】【F:backend/src/main/java/com/example/worktime/controller/WorkerController.java†L74-L107】
+## 2. 主界面布局
+登录后可以看到顶部导航栏，常用功能依次为：
+- **Excel 上传**：导入并修正工时记录的主页面。
+- **扫码录入**：使用条形码快速查询或补录记录。
+- **人员管理**：维护员工工号、姓名、班组等信息。
+- **工序代码**：维护工序代号与名称的对应关系。
+- **操作记录**：查看谁在什么时候做过哪些操作。
 
-## 7. 工序代码管理
-- 页面结构与人员管理类似，可按代号或名称搜索，支持在线编辑大类、内容等字段，并通过模态框新增工序代码，内置冲突提示以便发现重复代号。【F:frontend/src/components/ProcessManager.vue†L1-L188】
-- 服务端在新增或更新时会确保代号、名称非空且全局唯一，`ProcessCodeService` 会缓存名称到代号的映射，并建立代号索引供缺陷检测和自动补全使用；`/api/processcodes/remember` 还允许从上传页直接记忆名称-代号配对。【F:backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java†L17-L118】【F:backend/src/main/java/com/example/worktime/service/ProcessCodeService.java†L19-L120】【F:backend/src/main/java/com/example/worktime/service/ProcessCodeService.java†L121-L205】
+点击导航名称即可切换到对应功能页面。系统支持在多个标签页同时打开不同功能，操作互不影响。
 
-## 8. 操作记录中心
-- 操作记录页提供用户、关键字、日期范围、模块、实体类型/ID、客户端 IP、Trace ID、状态码及耗时区间等筛选项，支持修改每页条数、重置、手动刷新及自动每分钟刷新。【F:frontend/src/components/OperationLog.vue†L3-L135】
-- 列表点击可展开详情查看请求方式、路径、实体标识及响应详情，支持复制到剪贴板；相同 Trace ID 的记录会自动分组展示主从关系，便于追踪批量操作。【F:frontend/src/components/OperationLog.vue†L96-L133】【F:frontend/src/components/OperationLog.vue†L220-L236】【F:frontend/src/components/OperationLog.vue†L305-L332】
-- 后端分页接口 `/api/logs` 支持上述筛选条件，所有条件都会在查询时构建 JPA Specification；过滤器会在每次请求时记录用户名、模块、摘要、状态码、耗时、客户端、请求/响应体，并附带 Trace ID 与线程上下文中收集到的业务实体信息。【F:backend/src/main/java/com/example/worktime/controller/OperationLogController.java†L27-L90】【F:backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java†L24-L87】【F:backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java†L88-L147】
-- 业务代码在执行时可通过 `OperationLogContext` 注入模块、实体、摘要和补充详情，配合 `OperationLogService.log` 写入数据库并阻止重复记录，保证日志详情清晰完整。【F:backend/src/main/java/com/example/worktime/service/OperationLogContext.java†L13-L71】【F:backend/src/main/java/com/example/worktime/service/OperationLogService.java†L17-L36】
+---
 
-## 9. 上传文件管理
-- 历史文件下拉列表来自 `/api/files` 接口，它会连同记录数量一起返回；删除文件时会级联清除关联工时记录，并把文件名、删除数量写入操作日志。【F:backend/src/main/java/com/example/worktime/controller/UploadedFileController.java†L30-L48】
-- 上传接口允许保留原始 Excel 数据（`store` 参数默认为 true），方便后续下载或审计；文件 ID 会回传给前端用于再次加载或打印。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L587-L644】
+## 3. Excel 上传流程
+### 3.1 准备导入
+1. 进入 **“Excel 上传”** 页面。
+2. 点击页面上方的 **“选择文件”** 按钮，从电脑中选取 Excel 文件（支持 `.xls` 和 `.xlsx`）。
+3. 选择后文件名会显示在按钮旁边，点击 **“解析并上传”** 开始处理。
 
-## 10. 条形码与补录规则
-- 系统提供 `/api/workrecords/generateBarcode(s)` 接口生成 Code128 条码图片，上传与自动保存时会对条码进行 Unicode 归一化与空白清理，并在缺少工序代码时自动清空条码，防止错误数据混入。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L350-L374】【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L450-L734】
-- 保存或自动保存时若检测到条码在其它记录中已存在，会把该条目标记为补录（supplemental），方便后续统计与打印时区分。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L450-L573】
+### 3.2 解析与保存
+- 解析过程中，进度条会显示当前进度，文件越大时间越长，期间无需刷新页面。
+- 上传完成后，系统会自动：
+  - 将文件登记到历史列表；
+  - 把解析出的每一行保存到数据库；
+  - 在页面下方显示预览表格，并统计缺陷数量。
 
-## 11. 业务日志与回溯
-- 所有与工时记录、人员、工序、文件相关的新增/修改/删除操作都会在对应控制器内设置模块、实体 ID 与摘要，并借助过滤器追加状态码、耗时、请求体，方便在操作记录中按图号、Trace ID 或实体快速回溯业务动作。【F:backend/src/main/java/com/example/worktime/controller/WorkRecordController.java†L470-L584】【F:backend/src/main/java/com/example/worktime/controller/WorkerController.java†L74-L107】【F:backend/src/main/java/com/example/worktime/controller/ProcessCodeController.java†L62-L118】【F:backend/src/main/java/com/example/worktime/controller/UploadedFileController.java†L35-L48】【F:backend/src/main/java/com/example/worktime/filter/OperationLogFilter.java†L24-L147】
+### 3.3 表格编辑
+- 表格按“图号”分组显示，每个图号是一页，可用右上角的页码快速翻页或在搜索框输入图号快速定位。
+- 双击单元格即可修改内容（计划数、单件工时、工序代码等）。修改后会立即自动保存，无需手动点击按钮。
+- 行左侧的彩色标签表示缺陷类型：
+  - 红色：缺少工序代码或条形码；
+  - 橙色：缺少计划数、单件工时等必填项；
+  - 蓝色：补录记录或其他提醒。
+
+### 3.4 缺陷面板
+- 页面左侧的 **“缺陷追踪”** 面板列出了所有问题项，按图号和问题类型分组。
+- 点击某个缺陷组，表格会自动过滤到对应行，方便集中处理。
+- 处理完毕后点击 **“清除筛选”** 返回全部记录。
+- 需要批量修正时，可在缺陷面板中点击 **“批量填写”**，在弹出的对话框里一次性填入工序代码、计划数等内容。
+
+### 3.5 常用工具按钮
+位于表格上方的工具条包含：
+- **清除0工序**：把工序代码为 0 或空的行清理出来，便于再次检查。
+- **保存**：将当前图号下所有已填写完整的记录重新提交数据库，用于确认全部修改已同步成功（自动保存已在后台完成，此按钮主要用于人工确认）。
+- **打印**：进入打印预览，所有图号会按页展示，并在每页左下角显示“图号：XXX”。
+- **删除文件**：在历史列表中选中某个文件后，点击删除即可移除该文件及其记录。
+
+---
+
+## 4. 历史文件管理
+1. 在“Excel 上传”页面右侧的 **“历史文件”** 下拉框中选择需要查看的文件。
+2. 系统会加载该文件中所有记录并显示在表格中，可直接再次修改。
+3. 若只想查看而不修改，可在顶部切换为只读模式；如需调整请保持默认编辑模式。
+4. 删除历史文件会同时删除对应的所有记录，请谨慎操作。删除后无法恢复，除非重新上传原始文件。
+
+---
+
+## 5. 打印与导出
+### 5.1 打印
+1. 在“Excel 上传”页面完成核对后，点击工具条上的 **“打印”**。
+2. 系统会自动整合所有图号，生成打印预览。
+3. 预览中每页底部左侧都会显示当前图号，例如“图号：A123-01”。
+4. 检查页眉页脚设置是否符合需求，确认后选择打印机并执行打印。
+
+### 5.2 下载原始文件
+- 在历史文件列表中点击某一条记录右侧的 **“下载”**（若管理员已开启该功能），即可保存上传时的原始 Excel 备用。
+
+---
+
+## 6. 扫码录入与补录
+### 6.1 查询与补录
+1. 切换到 **“扫码录入”** 页面。
+2. 在顶部输入框中直接扫描条形码或手动输入条码号，按回车即可查询。
+3. 匹配成功时，表格会显示对应记录，可在下方修改实际产量、人员分配、起止时间等信息。
+4. 如需新增记录，可点击 **“新增条码”**，填写必要字段后保存。
+
+### 6.2 批量操作
+- 选择多条记录后，可使用 **“保存全部”** 或 **“删除”** 完成批量处理。
+- **“复制”** 功能可快速复制某条记录并修改条码，用于补录同类工序。
+
+### 6.3 导出
+- 页面右上角提供两种导出方式：
+  - 按自然月导出：选择年份与月份，系统会自动计算 26 日为分界的自然月。
+  - 按图号导出：输入图号后导出该图号的全部记录。
+
+---
+
+## 7. 人员管理
+1. 点击顶部导航中的 **“人员管理”**。
+2. 页面上方的搜索框可按工号或姓名快速定位员工。
+3. 表格中的字段（班组、岗位等）支持直接编辑，修改后点击右上角的 **“保存修改”**。
+4. 添加新员工：
+   - 点击 **“新增人员”** 按钮打开弹窗；
+   - 填写工号、姓名、班组等信息；
+   - 点击 **“保存”**，成功后新员工会出现在列表顶部。
+5. 删除员工：选中对应行，点击 **“删除”**。若该员工仍在使用中，系统会弹出提示。
+
+---
+
+## 8. 工序代码管理
+1. 打开 **“工序代码”** 页面。
+2. 可在搜索框中输入工序代号或名称，快速查找现有记录。
+3. 直接在表格中修改工序名称、所属大类等字段，完成后点击 **“保存修改”**。
+4. 添加新工序代码：
+   - 点击 **“新增工序代码”**；
+   - 在弹窗中填写代号、工序名称及其他说明；
+   - 点击 **“保存”**，系统会自动检查是否与现有代号或名称重复。
+5. 删除工序：在列表中选中目标行，点击 **“删除”**。若该工序已在工时记录中使用，系统会发出警告。
+
+---
+
+## 9. 操作记录中心
+1. 进入 **“操作记录”** 页面，可查看所有用户在系统中的操作痕迹。
+2. 左上角的筛选条件包括：用户、时间范围、关键字、所属模块、实体类型、状态码、耗时范围等。
+3. 选择条件后点击 **“查询”**，列表会刷新；点击 **“重置”** 可清空所有筛选条件。
+4. 列表每行显示操作时间、用户、模块、摘要等信息。点击行右侧的 **“详情”**，可查看请求内容、返回结果、关联的图号或记录编号，并可一键复制。
+5. 页面支持定时刷新，开启后每分钟自动更新一次，便于实时监控。
+
+---
+
+## 10. 常见问题与建议
+- **解析失败或进度条停滞**：确认文件格式正确、内容没有合并单元格或隐藏工作表，必要时拆分成多个文件再上传。
+- **缺陷仍然存在**：修改后若提示未消失，检查是否所有必填项都已填写，并刷新页面确认是否保存成功。
+- **打印图号为空**：若页面底部显示“图号：（空）”，说明当前记录未填写图号，请回到表格补充。
+- **扫码无反应**：检查扫描设备是否正常输出；也可在输入框中直接键入条码号回车测试。
+- **操作权限问题**：若遇到“没有权限”提示，请联系管理员确认账号角色。
+
+---
+
+## 11. 支持与反馈
+如在使用过程中遇到无法解决的问题，请记录以下信息并反馈给系统管理员：
+- 问题发生的时间和页面；
+- 使用的账号及所做操作；
+- 页面上出现的具体提示或截图。
+
+管理员收到反馈后，可通过操作记录中心快速定位问题来源并协助处理。
+

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,9 +7,9 @@
           <a class="navbar-brand" href="#">单件工时录入</a>
           <ul class="navbar-nav">
             <li class="nav-item"><router-link class="nav-link" to="/upload">Excel上传</router-link></li>
-            <li class="nav-item"><router-link class="nav-link" to="/records">扫码录入</router-link></li>
-            <li class="nav-item"><router-link class="nav-link" to="/workers">人员管理</router-link></li>
-            <li class="nav-item"><router-link class="nav-link" to="/processes">工序代码</router-link></li>
+            <li class="nav-item" v-if="showAdvanced"><router-link class="nav-link" to="/records">扫码录入</router-link></li>
+            <li class="nav-item" v-if="showAdvanced"><router-link class="nav-link" to="/workers">人员管理</router-link></li>
+            <li class="nav-item" v-if="showAdvanced"><router-link class="nav-link" to="/processes">工序代码</router-link></li>
             <li class="nav-item"><router-link class="nav-link" to="/logs">操作记录</router-link></li>
             <li class="nav-item"><a href="#" class="nav-link" @click.prevent="logout">退出登录</a></li>
           </ul>
@@ -25,25 +25,38 @@
 <script>
 import LoginPage from './components/LoginPage.vue'
 
+const DEPARTMENT_PRODUCTION = 'production'
+
 export default {
   components: { LoginPage },
   data() {
-    return { loggedIn: false }
+    return {
+      loggedIn: false,
+      department: ''
+    }
+  },
+  computed: {
+    showAdvanced() {
+      return this.department !== DEPARTMENT_PRODUCTION
+    }
   },
   created() {
     this.loggedIn = localStorage.getItem('loggedIn') === 'true'
+    this.department = localStorage.getItem('department') || ''
   },
   methods: {
-   onLogin() {
+    onLogin(payload = {}) {
       this.loggedIn = true
-      localStorage.setItem('loggedIn','true')
-      // keep username from LoginPage
-   },
-   logout() {
+      localStorage.setItem('loggedIn', 'true')
+      this.department = payload.department || localStorage.getItem('department') || ''
+    },
+    logout() {
       this.loggedIn = false
+      this.department = ''
       localStorage.removeItem('loggedIn')
       localStorage.removeItem('username')
-   },
+      localStorage.removeItem('department')
+    },
     onSaved() {
       const v = this.$refs.view
       if (v && v.fetch) v.fetch()

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -234,6 +234,7 @@ body {
 
 .print-text { display: none; }
 .print-only { display: none; }
+.print-footer { display: none; }
 
 .screen-only { display: block; }
 .print-area { display: none; }
@@ -254,6 +255,16 @@ body {
   .no-print { display: none !important; }
   .print-text { display: inline !important; }
   .print-only { display: table-cell !important; }
+  .print-footer {
+    display: block !important;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    text-align: right;
+    font-size: 9pt;
+    color: #6c757d;
+  }
 
   .navbar {
     display: none !important;
@@ -324,6 +335,8 @@ body {
     margin-right: 0 !important;
     page-break-inside: avoid;
     break-inside: avoid;
+    position: relative;
+    padding-bottom: 22px;
   }
 
   #preview-table table {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -261,9 +261,10 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    text-align: right;
+    text-align: left;
     font-size: 9pt;
     color: #6c757d;
+    padding-left: 8px;
   }
 
   .navbar {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -234,7 +234,6 @@ body {
 
 .print-text { display: none; }
 .print-only { display: none; }
-.print-footer { display: none; }
 
 .screen-only { display: block; }
 .print-area { display: none; }
@@ -255,18 +254,6 @@ body {
   .no-print { display: none !important; }
   .print-text { display: inline !important; }
   .print-only { display: table-cell !important; }
-  .print-footer {
-    display: block !important;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    text-align: left;
-    font-size: 9pt;
-    color: #6c757d;
-    padding-left: 8px;
-  }
-
   .navbar {
     display: none !important;
   }
@@ -337,7 +324,20 @@ body {
     page-break-inside: avoid;
     break-inside: avoid;
     position: relative;
-    padding-bottom: 22px;
+    padding-bottom: 28px;
+  }
+
+  #preview-table .preview-page::after {
+    content: attr(data-print-footer);
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 4mm;
+    font-size: 9pt;
+    color: #6c757d;
+    padding-left: 8px;
+    pointer-events: none;
   }
 
   #preview-table table {

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -23,6 +23,10 @@ body {
   min-width: 0;
 }
 
+#preview-table .print-page-footer {
+  display: none;
+}
+
 .issue-panel {
   position: sticky;
   top: 1rem;
@@ -324,20 +328,23 @@ body {
     page-break-inside: avoid;
     break-inside: avoid;
     position: relative;
-    padding-bottom: 28px;
+    padding-bottom: 36px;
   }
 
-  #preview-table .preview-page::after {
-    content: attr(data-print-footer);
+  #preview-table .print-page-footer {
     display: block;
     position: absolute;
     left: 0;
-    right: 0;
-    bottom: 4mm;
+    bottom: -14mm;
+    width: calc(100% + 20mm);
+    margin-left: -10mm;
+    padding-left: 10mm;
     font-size: 9pt;
     color: #6c757d;
-    padding-left: 8px;
     pointer-events: none;
+    white-space: nowrap;
+    background: #fff;
+    z-index: 5;
   }
 
   #preview-table table {

--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -13,6 +13,18 @@
           <label class="form-label visually-hidden" for="password">密码</label>
           <input id="password" type="password" class="form-control form-control-lg" v-model.trim="password" placeholder="密码" autocomplete="current-password" />
         </div>
+        <div class="mb-4">
+          <label class="form-label" for="department">请选择部门</label>
+          <select
+            id="department"
+            class="form-select form-select-lg"
+            v-model="department"
+          >
+            <option disabled value="">请选择登录部门</option>
+            <option value="production">生产部门</option>
+            <option value="process">工艺部门</option>
+          </select>
+        </div>
         <button class="btn btn-primary btn-lg w-100" :disabled="loading || !canSubmit">
           <span v-if="loading" class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
           登录
@@ -31,13 +43,14 @@ export default {
     return {
       username: '',
       password: '',
+      department: '',
       loading: false,
       error: ''
     };
   },
   computed: {
     canSubmit() {
-      return this.username && this.password;
+      return this.username && this.password && this.department;
     }
   },
   methods: {
@@ -56,7 +69,8 @@ export default {
         );
         localStorage.setItem('loggedIn', 'true');
         localStorage.setItem('username', this.username);
-        this.$emit('logged-in');
+        localStorage.setItem('department', this.department);
+        this.$emit('logged-in', { department: this.department });
       } catch (e) {
         this.error = e.response?.data?.message || '登录失败，请稍后再试';
       } finally {

--- a/frontend/src/components/OperationLog.vue
+++ b/frontend/src/components/OperationLog.vue
@@ -1,24 +1,85 @@
 <template>
   <section class="section-card">
     <h2 class="h5">操作记录</h2>
+    <form class="log-filter" @submit.prevent="applyFilters">
+      <div class="log-filter__row">
+        <label class="log-filter__field">
+          <span>用户</span>
+          <input v-model.trim="filters.username" type="text" class="form-control form-control-sm" placeholder="用户名" />
+        </label>
+        <label class="log-filter__field">
+          <span>关键字</span>
+          <input v-model.trim="filters.keyword" type="text" class="form-control form-control-sm" placeholder="动作或详情关键词" />
+        </label>
+        <label class="log-filter__field">
+          <span>开始日期</span>
+          <input v-model="filters.start" type="date" class="form-control form-control-sm" />
+        </label>
+        <label class="log-filter__field">
+          <span>结束日期</span>
+          <input v-model="filters.end" type="date" class="form-control form-control-sm" />
+        </label>
+        <label class="log-filter__field log-filter__field--size">
+          <span>每页条数</span>
+          <select v-model.number="size" class="form-select form-select-sm">
+            <option :value="20">20</option>
+            <option :value="50">50</option>
+            <option :value="100">100</option>
+          </select>
+        </label>
+      </div>
+      <div class="log-filter__actions">
+        <div class="log-filter__buttons">
+          <button type="submit" class="btn btn-primary btn-sm" :disabled="loading">筛选</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="loading" @click="resetFilters">重置</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm" :disabled="loading" @click="refresh">刷新</button>
+        </div>
+        <label class="log-filter__auto">
+          <input type="checkbox" v-model="autoRefresh" /> 自动刷新
+        </label>
+      </div>
+    </form>
+    <div class="log-pagination">
+      <div>共 {{ total }} 条记录，当前第 {{ page + 1 }} / {{ pageCount || 1 }} 页</div>
+      <div class="log-pagination__actions">
+        <button class="btn btn-outline-secondary btn-sm" :disabled="loading || page === 0" @click="changePage(page - 1)">上一页</button>
+        <button class="btn btn-outline-secondary btn-sm" :disabled="loading || page + 1 >= pageCount" @click="changePage(page + 1)">下一页</button>
+      </div>
+    </div>
     <table class="table table-bordered table-sm table-striped">
       <thead>
         <tr><th>时间</th><th>操作者</th><th>操作</th></tr>
       </thead>
       <tbody>
-        <template v-for="log in logs">
-          <tr :key="log.id" @click="log.show = !log.show" style="cursor:pointer">
-            <td>{{ log.timestamp.replace('T',' ').slice(0,19) }}</td>
+        <template v-for="log in logs" :key="log.id">
+          <tr @click="toggleDetails(log)" style="cursor:pointer">
+            <td>{{ formatTimestamp(log.timestamp) }}</td>
             <td>{{ log.username }}</td>
             <td class="wrap-text">{{ log.action }}</td>
           </tr>
           <tr v-if="log.show" :key="log.id + '-details'">
             <td colspan="3" class="pre-wrap">
-              <div v-if="log.details">{{ log.details }}</div>
-              <div v-for="s in log.sub" :key="s.id">{{ s.action }}</div>
+              <div class="log-details__header">
+                <span>详细信息</span>
+                <button class="btn btn-outline-secondary btn-sm" @click.stop="copyDetails(log)">复制详情</button>
+              </div>
+              <pre v-if="log.details" class="log-details__body">{{ log.details }}</pre>
+              <div v-if="!log.details" class="text-muted">暂无详情</div>
+              <div v-if="log.sub && log.sub.length" class="log-details__children">
+                <div class="log-details__child" v-for="s in log.sub" :key="s.id">
+                  <div class="log-details__child-time">{{ formatTimestamp(s.timestamp) }}</div>
+                  <div class="log-details__child-text">{{ s.action }}</div>
+                </div>
+              </div>
             </td>
           </tr>
         </template>
+        <tr v-if="!logs.length && !loading">
+          <td colspan="3" class="text-center text-muted">暂无符合条件的记录</td>
+        </tr>
+        <tr v-if="loading">
+          <td colspan="3" class="text-center text-muted">加载中...</td>
+        </tr>
       </tbody>
     </table>
   </section>
@@ -26,17 +87,67 @@
 
 <script>
 import axios from 'axios'
+
 export default {
   data() {
-    return { logs: [] }
+    return {
+      logs: [],
+      total: 0,
+      page: 0,
+      size: 20,
+      pageCount: 0,
+      loading: false,
+      autoRefresh: false,
+      refreshTimer: null,
+      filters: {
+        username: '',
+        keyword: '',
+        start: '',
+        end: ''
+      }
+    }
   },
-  created() { this.fetchLogs() },
+  created() {
+    this.fetchLogs()
+  },
+  watch: {
+    size() {
+      this.fetchLogs(true)
+    },
+    autoRefresh(val) {
+      this.setupAutoRefresh(val)
+    }
+  },
+  beforeDestroy() {
+    this.setupAutoRefresh(false)
+  },
   methods: {
-    async fetchLogs() {
+    async fetchLogs(resetPage = false) {
+      if (resetPage) this.page = 0
+      this.loading = true
       const user = localStorage.getItem('username')
       const headers = user ? { 'X-User': user } : {}
-      const res = await axios.get('/api/logs', { headers })
-      this.logs = this.groupLogs(res.data)
+      const params = new URLSearchParams()
+      params.set('page', this.page)
+      params.set('size', this.size)
+      if (this.filters.username) params.set('username', this.filters.username)
+      if (this.filters.keyword) params.set('keyword', this.filters.keyword)
+      if (this.filters.start) params.set('startDate', this.filters.start)
+      if (this.filters.end) params.set('endDate', this.filters.end)
+      try {
+        const res = await axios.get('/api/logs', { headers, params })
+        const payload = res.data || {}
+        const content = payload.content || []
+        this.total = payload.totalElements ?? content.length
+        this.pageCount = payload.totalPages ?? (content.length ? 1 : 0)
+        if (this.pageCount > 0 && this.page >= this.pageCount) {
+          this.page = this.pageCount - 1
+          return this.fetchLogs()
+        }
+        this.logs = this.groupLogs(content)
+      } finally {
+        this.loading = false
+      }
     },
     groupLogs(raw) {
       const grouped = []
@@ -53,6 +164,61 @@ export default {
         }
       }
       return grouped
+    },
+    formatTimestamp(value) {
+      if (!value) return ''
+      return value.replace('T', ' ').slice(0, 19)
+    },
+    toggleDetails(log) {
+      log.show = !log.show
+    },
+    changePage(next) {
+      if (next < 0 || (this.pageCount && next >= this.pageCount)) return
+      this.page = next
+      this.fetchLogs()
+    },
+    applyFilters() {
+      this.fetchLogs(true)
+    },
+    resetFilters() {
+      this.filters = { username: '', keyword: '', start: '', end: '' }
+      this.fetchLogs(true)
+    },
+    refresh() {
+      this.fetchLogs()
+    },
+    setupAutoRefresh(enable) {
+      if (this.refreshTimer) {
+        clearInterval(this.refreshTimer)
+        this.refreshTimer = null
+      }
+      if (enable) {
+        this.refreshTimer = setInterval(() => {
+          if (!this.loading) {
+            this.fetchLogs()
+          }
+        }, 60000)
+      }
+    },
+    async copyDetails(log) {
+      const text = [log.action, log.details].filter(Boolean).join('\n')
+      if (!text) return
+      try {
+        await navigator.clipboard.writeText(text)
+        if (this.$bvToast) {
+          this.$bvToast.toast('已复制到剪贴板', { variant: 'success', autoHideDelay: 1500 })
+        }
+      } catch (e) {
+        const textarea = document.createElement('textarea')
+        textarea.value = text
+        textarea.style.position = 'fixed'
+        textarea.style.opacity = '0'
+        document.body.appendChild(textarea)
+        textarea.focus()
+        textarea.select()
+        document.execCommand('copy')
+        document.body.removeChild(textarea)
+      }
     }
   }
 }
@@ -60,4 +226,86 @@ export default {
 
 <style>
 .pre-wrap { white-space: pre-wrap; }
+.log-filter {
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+  margin-bottom: 1rem;
+}
+.log-filter__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+}
+.log-filter__field {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+  min-width: 140px;
+}
+.log-filter__field--size {
+  width: 120px;
+}
+.log-filter__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.log-filter__buttons {
+  display: flex;
+  gap: .5rem;
+}
+.log-filter__auto {
+  display: flex;
+  align-items: center;
+  gap: .25rem;
+  font-size: .875rem;
+  color: #6c757d;
+}
+.log-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: .5rem;
+  font-size: .875rem;
+}
+.log-pagination__actions {
+  display: flex;
+  gap: .5rem;
+}
+.log-details__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: .5rem;
+}
+.log-details__body {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: .25rem;
+  padding: .5rem .75rem;
+  white-space: pre-wrap;
+}
+.log-details__children {
+  margin-top: .5rem;
+  border-top: 1px dashed #dee2e6;
+  padding-top: .5rem;
+  display: grid;
+  gap: .35rem;
+}
+.log-details__child {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: .75rem;
+  font-size: .875rem;
+}
+.log-details__child-time {
+  color: #6c757d;
+}
+.log-details__child-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
 </style>

--- a/frontend/src/components/OperationLog.vue
+++ b/frontend/src/components/OperationLog.vue
@@ -28,6 +28,40 @@
           </select>
         </label>
       </div>
+      <div class="log-filter__row">
+        <label class="log-filter__field">
+          <span>模块</span>
+          <input v-model.trim="filters.module" type="text" class="form-control form-control-sm" placeholder="模块" />
+        </label>
+        <label class="log-filter__field">
+          <span>实体类型</span>
+          <input v-model.trim="filters.entityType" type="text" class="form-control form-control-sm" placeholder="实体类型" />
+        </label>
+        <label class="log-filter__field">
+          <span>实体ID</span>
+          <input v-model.trim="filters.entityId" type="text" class="form-control form-control-sm" placeholder="实体ID" />
+        </label>
+        <label class="log-filter__field">
+          <span>客户端IP</span>
+          <input v-model.trim="filters.clientIp" type="text" class="form-control form-control-sm" placeholder="客户端IP" />
+        </label>
+        <label class="log-filter__field">
+          <span>Trace ID</span>
+          <input v-model.trim="filters.traceId" type="text" class="form-control form-control-sm" placeholder="Trace ID" />
+        </label>
+        <label class="log-filter__field log-filter__field--size">
+          <span>状态码</span>
+          <input v-model.number="filters.statusCode" type="number" class="form-control form-control-sm" placeholder="200" />
+        </label>
+        <label class="log-filter__field log-filter__field--size">
+          <span>耗时≥(ms)</span>
+          <input v-model.number="filters.minDuration" type="number" min="0" class="form-control form-control-sm" />
+        </label>
+        <label class="log-filter__field log-filter__field--size">
+          <span>耗时≤(ms)</span>
+          <input v-model.number="filters.maxDuration" type="number" min="0" class="form-control form-control-sm" />
+        </label>
+      </div>
       <div class="log-filter__actions">
         <div class="log-filter__buttons">
           <button type="submit" class="btn btn-primary btn-sm" :disabled="loading">筛选</button>
@@ -46,39 +80,57 @@
         <button class="btn btn-outline-secondary btn-sm" :disabled="loading || page + 1 >= pageCount" @click="changePage(page + 1)">下一页</button>
       </div>
     </div>
-    <table class="table table-bordered table-sm table-striped">
+    <table class="table table-bordered table-sm table-striped log-table">
       <thead>
-        <tr><th>时间</th><th>操作者</th><th>操作</th></tr>
+        <tr>
+          <th>时间</th>
+          <th>模块</th>
+          <th>操作者</th>
+          <th>摘要</th>
+          <th>状态</th>
+          <th>耗时</th>
+          <th>客户端</th>
+        </tr>
       </thead>
       <tbody>
         <template v-for="log in logs" :key="log.id">
           <tr @click="toggleDetails(log)" style="cursor:pointer">
             <td>{{ formatTimestamp(log.timestamp) }}</td>
+            <td>{{ log.module || '-' }}</td>
             <td>{{ log.username }}</td>
-            <td class="wrap-text">{{ log.action }}</td>
+            <td class="wrap-text">{{ log.summary || log.action }}</td>
+            <td>{{ log.statusCode ?? '-' }}</td>
+            <td>{{ formatDuration(log.durationMs) }}</td>
+            <td class="wrap-text">{{ log.clientIp || '-' }}</td>
           </tr>
           <tr v-if="log.show" :key="log.id + '-details'">
-            <td colspan="3" class="pre-wrap">
+            <td colspan="7" class="pre-wrap">
               <div class="log-details__header">
                 <span>详细信息</span>
                 <button class="btn btn-outline-secondary btn-sm" @click.stop="copyDetails(log)">复制详情</button>
+              </div>
+              <div class="log-details__meta">
+                <div><span>Trace ID</span><strong>{{ log.traceId || '-' }}</strong></div>
+                <div><span>请求</span><strong>{{ formatRequest(log) }}</strong></div>
+                <div><span>实体</span><strong>{{ formatEntity(log) }}</strong></div>
+                <div><span>User-Agent</span><strong>{{ log.userAgent || '-' }}</strong></div>
               </div>
               <pre v-if="log.details" class="log-details__body">{{ log.details }}</pre>
               <div v-if="!log.details" class="text-muted">暂无详情</div>
               <div v-if="log.sub && log.sub.length" class="log-details__children">
                 <div class="log-details__child" v-for="s in log.sub" :key="s.id">
                   <div class="log-details__child-time">{{ formatTimestamp(s.timestamp) }}</div>
-                  <div class="log-details__child-text">{{ s.action }}</div>
+                  <div class="log-details__child-text">{{ s.summary || s.action }}</div>
                 </div>
               </div>
             </td>
           </tr>
         </template>
         <tr v-if="!logs.length && !loading">
-          <td colspan="3" class="text-center text-muted">暂无符合条件的记录</td>
+          <td colspan="7" class="text-center text-muted">暂无符合条件的记录</td>
         </tr>
         <tr v-if="loading">
-          <td colspan="3" class="text-center text-muted">加载中...</td>
+          <td colspan="7" class="text-center text-muted">加载中...</td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +155,15 @@ export default {
         username: '',
         keyword: '',
         start: '',
-        end: ''
+        end: '',
+        module: '',
+        entityType: '',
+        entityId: '',
+        clientIp: '',
+        traceId: '',
+        statusCode: null,
+        minDuration: null,
+        maxDuration: null
       }
     }
   },
@@ -134,6 +194,14 @@ export default {
       if (this.filters.keyword) params.set('keyword', this.filters.keyword)
       if (this.filters.start) params.set('startDate', this.filters.start)
       if (this.filters.end) params.set('endDate', this.filters.end)
+      if (this.filters.module) params.set('module', this.filters.module)
+      if (this.filters.entityType) params.set('entityType', this.filters.entityType)
+      if (this.filters.entityId) params.set('entityId', this.filters.entityId)
+      if (this.filters.clientIp) params.set('clientIp', this.filters.clientIp)
+      if (this.filters.traceId) params.set('traceId', this.filters.traceId)
+      if (Number.isInteger(this.filters.statusCode)) params.set('statusCode', this.filters.statusCode)
+      if (Number.isInteger(this.filters.minDuration)) params.set('minDuration', this.filters.minDuration)
+      if (Number.isInteger(this.filters.maxDuration)) params.set('maxDuration', this.filters.maxDuration)
       try {
         const res = await axios.get('/api/logs', { headers, params })
         const payload = res.data || {}
@@ -151,16 +219,17 @@ export default {
     },
     groupLogs(raw) {
       const grouped = []
-      let current = null
+      const traceGroups = new Map()
       for (const log of raw) {
         log.show = false
         log.sub = log.sub || []
-        const isApi = /^(GET|POST|PUT|DELETE|PATCH) /.test(log.action) && !log.details
-        if (isApi && current) {
-          current.sub.push(log)
-        } else {
-          grouped.push(log)
-          current = log
+        if (log.traceId && traceGroups.has(log.traceId)) {
+          traceGroups.get(log.traceId).sub.push(log)
+          continue
+        }
+        grouped.push(log)
+        if (log.traceId) {
+          traceGroups.set(log.traceId, log)
         }
       }
       return grouped
@@ -168,6 +237,26 @@ export default {
     formatTimestamp(value) {
       if (!value) return ''
       return value.replace('T', ' ').slice(0, 19)
+    },
+    formatDuration(value) {
+      if (value === null || value === undefined) return '-'
+      if (value >= 1000) {
+        return (value / 1000).toFixed(2) + ' s'
+      }
+      return value + ' ms'
+    },
+    formatRequest(log) {
+      const method = log.method || '-'
+      const path = log.path || ''
+      const query = log.query ? `?${log.query}` : ''
+      return `${method} ${path}${query}`.trim()
+    },
+    formatEntity(log) {
+      if (!log.entityType && !log.entityId) return '-'
+      if (log.entityType && log.entityId) {
+        return `${log.entityType}#${log.entityId}`
+      }
+      return log.entityType || log.entityId
     },
     toggleDetails(log) {
       log.show = !log.show
@@ -181,7 +270,20 @@ export default {
       this.fetchLogs(true)
     },
     resetFilters() {
-      this.filters = { username: '', keyword: '', start: '', end: '' }
+      this.filters = {
+        username: '',
+        keyword: '',
+        start: '',
+        end: '',
+        module: '',
+        entityType: '',
+        entityId: '',
+        clientIp: '',
+        traceId: '',
+        statusCode: null,
+        minDuration: null,
+        maxDuration: null
+      }
       this.fetchLogs(true)
     },
     refresh() {
@@ -201,7 +303,15 @@ export default {
       }
     },
     async copyDetails(log) {
-      const text = [log.action, log.details].filter(Boolean).join('\n')
+      const text = [
+        `时间: ${this.formatTimestamp(log.timestamp)}`,
+        `用户: ${log.username}`,
+        `模块: ${log.module || '-'}`,
+        `摘要: ${log.summary || log.action}`,
+        `Trace: ${log.traceId || '-'}`,
+        `请求: ${this.formatRequest(log)}`,
+        log.details
+      ].filter(Boolean).join('\n')
       if (!text) return
       try {
         await navigator.clipboard.writeText(text)
@@ -242,6 +352,10 @@ export default {
   flex-direction: column;
   gap: .25rem;
   min-width: 140px;
+}
+.log-table th,
+.log-table td {
+  vertical-align: middle;
 }
 .log-filter__field--size {
   width: 120px;
@@ -287,6 +401,25 @@ export default {
   border-radius: .25rem;
   padding: .5rem .75rem;
   white-space: pre-wrap;
+}
+.log-details__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: .5rem .75rem;
+  margin-bottom: .5rem;
+  font-size: .85rem;
+}
+.log-details__meta span {
+  display: block;
+  color: #6c757d;
+  font-size: .75rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.log-details__meta strong {
+  display: block;
+  font-weight: 600;
+  word-break: break-word;
 }
 .log-details__children {
   margin-top: .5rem;

--- a/frontend/src/components/ProcessManager.vue
+++ b/frontend/src/components/ProcessManager.vue
@@ -29,15 +29,23 @@
       </tbody>
     </table>
     <!-- 新增工序代码模态框 -->
-    <div class="modal fade" tabindex="-1" ref="addModal">
-      <div class="modal-dialog modal-dialog-centered">
+    <div
+      class="modal fade show"
+      tabindex="-1"
+      role="dialog"
+      v-if="showAddModal"
+      style="display: block"
+      aria-modal="true"
+      @click.self="closeModal"
+    >
+      <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title">新增工序代码</h5>
             <button type="button" class="btn-close" @click="closeModal"></button>
           </div>
           <div class="modal-body">
-            <div class="mb-2"><input class="form-control form-control-sm" v-model="newProcess.code" placeholder="代号" /></div>
+            <div class="mb-2"><input class="form-control form-control-sm" v-model="newProcess.code" placeholder="代号" ref="codeInput" /></div>
             <div class="mb-2"><input class="form-control form-control-sm" v-model="newProcess.name" placeholder="工序名称" /></div>
             <div class="mb-2"><input class="form-control form-control-sm" v-model="newProcess.category" placeholder="大类" /></div>
             <div><input class="form-control form-control-sm" v-model="newProcess.content" placeholder="内容" /></div>
@@ -49,6 +57,7 @@
         </div>
       </div>
     </div>
+    <div v-if="showAddModal" class="modal-backdrop fade show"></div>
   </section>
 </template>
 
@@ -60,7 +69,7 @@ export default {
       processCodes: [],
       search: '',
       newProcess: { code: '', name: '', category: '', content: '' },
-      modal: null
+      showAddModal: false
     }
   },
   computed: {
@@ -74,21 +83,38 @@ export default {
   watch: {
     search(val) {
       this.fetchProcesses(val)
+    },
+    showAddModal(val) {
+      if (typeof document !== 'undefined' && document.body) {
+        if (val) {
+          document.body.classList.add('modal-open')
+        } else {
+          this.$nextTick(() => {
+            const remaining = document.querySelectorAll('.modal.fade.show')
+            if (!remaining.length) {
+              document.body.classList.remove('modal-open')
+            }
+          })
+        }
+      }
     }
   },
   created() {
     this.fetchProcesses('')
   },
-  mounted() {
-    this.modal = new window.bootstrap.Modal(this.$refs.addModal)
-  },
   methods: {
     openModal() {
       this.newProcess = { code: '', name: '', category: '', content: '' }
-      this.modal.show()
+      this.showAddModal = true
+      this.$nextTick(() => {
+        const input = this.$refs.codeInput
+        if (input && typeof input.focus === 'function') {
+          input.focus()
+        }
+      })
     },
     closeModal() {
-      this.modal.hide()
+      this.showAddModal = false
     },
     async fetchProcesses(term) {
       const url = term
@@ -157,6 +183,16 @@ export default {
         message = error.message
       }
       alert(message || fallback || '操作失败')
+    }
+  },
+  beforeUnmount() {
+    if (typeof document !== 'undefined' && document.body) {
+      this.$nextTick(() => {
+        const remaining = document.querySelectorAll('.modal.fade.show')
+        if (!remaining.length) {
+          document.body.classList.remove('modal-open')
+        }
+      })
     }
   }
 }

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -59,7 +59,6 @@
           <div
             class="preview-page"
             :class="{ 'active-page': item.index === currentPage, 'force-new-page': item.page.isFirstOfDrawing && item.index !== 0 }"
-            :data-print-footer="formatPrintFooter(item.page.drawingNumber)"
           >
             <div class="d-flex justify-content-between align-items-center mb-2 page-heading">
               <h3 class="h6 mb-0">图号：{{ item.page.drawingNumber || '（空）' }}</h3>
@@ -162,6 +161,9 @@
 
               </tbody>
             </table>
+            <div class="print-page-footer" aria-hidden="true">
+              {{ formatPrintFooter(item.page.drawingNumber) }}
+            </div>
           </div>
         </template>
       </div>

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -569,7 +569,7 @@ export default {
       catch (err) { return }
       this.loading = true; this.showProgress = true; this.parseProgress = 5; this.barcodeCache = {}; this.issueFilter = null; this.issueCompletionNotified = false
       try {
-        const data = new FormData(); data.append('file', this.file); data.append('store', 'false')
+        const data = new FormData(); data.append('file', this.file)
         const res = await axios.post('/api/workrecords/parse', data, { headers })
         const payload = res && res.data ? res.data : {}
         this.fileId = payload.fileId
@@ -963,8 +963,21 @@ export default {
       r.hoursMissing = r.hours == null || r.hours === ''
       this.updateIssueFlags(r)
     },
-    deleteRow(index) {
+    async deleteRow(index) {
+      const record = this.preview[index]
+      if (!record) return
       if (!confirm('确定删除该行? 删除后不可恢复')) return
+      if (record.id) {
+        let headers
+        try { headers = this.requireUserHeaders() }
+        catch (err) { return }
+        try {
+          await axios.delete(`/api/workrecords/${record.id}`, { headers })
+        } catch (error) {
+          this.handleRequestError(error, '删除记录失败')
+          return
+        }
+      }
       this.preview.splice(index, 1)
       this.$nextTick(() => this.ensurePageInRange())
     },
@@ -993,17 +1006,49 @@ export default {
       this.preview.splice(index + 1, 0, decorated)
       this.$nextTick(() => this.ensurePageInRange())
     },
-    deleteZero() {
+    async deleteZero() {
       if (!this.preview.length) return
       if (!confirm('确定删除所有工序为0的行?')) return
       const before = this.preview.length
+      const toRemove = this.preview.filter(r => {
+        const code = r.processCode != null ? String(r.processCode).trim() : ''
+        return code === '0'
+      })
+      if (!toRemove.length) {
+        alert('未找到工序为0的记录')
+        return
+      }
+      const idsToDelete = toRemove.map(r => r.id).filter(Boolean)
+      let headers = null
+      if (idsToDelete.length) {
+        try { headers = this.requireUserHeaders() }
+        catch (err) { return }
+      }
+      const failedIds = new Set()
+      let firstError = null
+      for (const id of idsToDelete) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await axios.delete(`/api/workrecords/${id}`, { headers })
+        } catch (error) {
+          if (!firstError) firstError = error
+          failedIds.add(id)
+        }
+      }
       this.preview = this.preview.filter(r => {
         const code = r.processCode != null ? String(r.processCode).trim() : ''
-        return code !== '0'
+        if (code !== '0') return true
+        if (r.id && failedIds.has(r.id)) return true
+        return false
       })
       this.preview.forEach(r => this.updateIssueFlags(r))
       const removed = before - this.preview.length
-      alert(`已删除${removed}行`)
+      if (firstError) {
+        this.handleRequestError(firstError, '部分记录删除失败')
+      }
+      const extra = failedIds.size ? '，部分记录删除失败' : ''
+      alert(`已删除${removed}行${extra}`)
+      this.$nextTick(() => this.ensurePageInRange())
     },
     async loadBarcodesForPage(pageIndex) {
       const page = this.pages[pageIndex]; if (!page) return

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -161,6 +161,9 @@
 
               </tbody>
             </table>
+            <div class="print-footer" aria-hidden="true">
+              图号：{{ item.page.drawingNumber || '（空）' }}
+            </div>
           </div>
         </template>
       </div>

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -59,6 +59,7 @@
           <div
             class="preview-page"
             :class="{ 'active-page': item.index === currentPage, 'force-new-page': item.page.isFirstOfDrawing && item.index !== 0 }"
+            :data-print-footer="formatPrintFooter(item.page.drawingNumber)"
           >
             <div class="d-flex justify-content-between align-items-center mb-2 page-heading">
               <h3 class="h6 mb-0">图号：{{ item.page.drawingNumber || '（空）' }}</h3>
@@ -161,9 +162,6 @@
 
               </tbody>
             </table>
-            <div class="print-footer" aria-hidden="true">
-              图号：{{ item.page.drawingNumber || '（空）' }}
-            </div>
           </div>
         </template>
       </div>
@@ -735,6 +733,11 @@ export default {
         remark2: asText(record.remark2)
       }
       return payload
+    },
+    formatPrintFooter(drawingNumber) {
+      const sanitized = drawingNumber == null ? '' : this.sanitize(drawingNumber)
+      const drawing = sanitized && sanitized.length ? sanitized : '（空）'
+      return `图号：${drawing}`
     },
     async autoSaveRecord(record) {
       if (!record) return

--- a/frontend/src/components/RecordUpload.vue
+++ b/frontend/src/components/RecordUpload.vue
@@ -375,57 +375,67 @@ export default {
       deep: true
     }
   },
-  methods: {
-    hasText(value) {
-      if (value === null || value === undefined) return false
-      return String(value).trim().length > 0
-    },
-    decorateRecord(raw) {
-      const record = { ...raw }
-      record.notificationNumber = record.notificationNumber != null ? String(record.notificationNumber).trim() : ''
-      record.productName = record.productName != null ? String(record.productName).trim() : ''
-      record.drawingNumber = record.drawingNumber != null ? String(record.drawingNumber).trim() : ''
-      record.partName = record.partName != null ? String(record.partName).trim() : ''
-      record.processName = record.processName != null ? String(record.processName).trim() : ''
-      record.processCode = record.processCode != null ? String(record.processCode).trim() : ''
-      if (record.planQty !== null && record.planQty !== undefined && record.planQty !== '') {
-        const num = Number(record.planQty)
-        record.planQty = Number.isNaN(num) ? null : num
-      } else {
-        record.planQty = null
-      }
-      if (record.hours !== null && record.hours !== undefined && record.hours !== '') {
-        const num = Number(record.hours)
-        record.hours = Number.isNaN(num) ? null : num
-      } else {
-        record.hours = null
-      }
-      const rawBarcode = record.barcode != null ? String(record.barcode).trim() : ''
-      record.barcode = this.sanitize(rawBarcode)
-      record.barcodeImage = record.barcodeImage || ''
-      record.workerCodes = record.workerCodes || ''
-      record.qualifiedQty = record.qualifiedQty != null ? Number(record.qualifiedQty) : null
-      record.hourSubtotal = record.hourSubtotal != null ? Number(record.hourSubtotal) : null
-      const sourceCodeMissing = record.codeMissing === true
-      record.codeMissing = sourceCodeMissing
-      record.serverCodeMissing = sourceCodeMissing
-      record.hoursMissing = record.hoursMissing === true
-      record.notificationMissing = record.notificationMissing === true
-      record.productMissing = record.productMissing === true
-      record.partMissing = record.partMissing === true
-      record.drawingMissing = record.drawingMissing === true
-      record.planMissing = record.planMissing === true
-      record.processMissing = record.processMissing === true
-      record.barcodeMissing = record.barcodeMissing === true
-      record.issueSummary = ''
-      record.hasIssue = false
-      record.issueTypes = []
-      record._lastAcceptedProcessCode = record.processCode
-      record._lastAcceptedBarcode = record.barcode
-      record._lastAcceptedBarcodeImage = record.barcodeImage
-      this.updateIssueFlags(record)
-      return record
-    },
+    methods: {
+      hasText(value) {
+        if (value === null || value === undefined) return false
+        return String(value).trim().length > 0
+      },
+      normalizeProcessCode(value) {
+        if (value === null || value === undefined) return ''
+        const text = String(value).trim()
+        if (!text || text === '0') return ''
+        return text
+      },
+      isValidProcessCode(value) {
+        return this.normalizeProcessCode(value) !== ''
+      },
+      decorateRecord(raw) {
+        const record = { ...raw }
+        record.notificationNumber = record.notificationNumber != null ? String(record.notificationNumber).trim() : ''
+        record.productName = record.productName != null ? String(record.productName).trim() : ''
+        record.drawingNumber = record.drawingNumber != null ? String(record.drawingNumber).trim() : ''
+        record.partName = record.partName != null ? String(record.partName).trim() : ''
+        record.processName = record.processName != null ? String(record.processName).trim() : ''
+        const normalizedCode = this.normalizeProcessCode(record.processCode)
+        record.processCode = normalizedCode
+        if (record.planQty !== null && record.planQty !== undefined && record.planQty !== '') {
+          const num = Number(record.planQty)
+          record.planQty = Number.isNaN(num) ? null : num
+        } else {
+          record.planQty = null
+        }
+        if (record.hours !== null && record.hours !== undefined && record.hours !== '') {
+          const num = Number(record.hours)
+          record.hours = Number.isNaN(num) ? null : num
+        } else {
+          record.hours = null
+        }
+        const rawBarcode = record.barcode != null ? String(record.barcode).trim() : ''
+        record.barcode = this.sanitize(rawBarcode)
+        record.barcodeImage = record.barcodeImage || ''
+        record.workerCodes = record.workerCodes || ''
+        record.qualifiedQty = record.qualifiedQty != null ? Number(record.qualifiedQty) : null
+        record.hourSubtotal = record.hourSubtotal != null ? Number(record.hourSubtotal) : null
+        const sourceCodeMissing = record.codeMissing === true || !normalizedCode
+        record.codeMissing = sourceCodeMissing
+        record.serverCodeMissing = sourceCodeMissing
+        record.hoursMissing = record.hoursMissing === true
+        record.notificationMissing = record.notificationMissing === true
+        record.productMissing = record.productMissing === true
+        record.partMissing = record.partMissing === true
+        record.drawingMissing = record.drawingMissing === true
+        record.planMissing = record.planMissing === true
+        record.processMissing = record.processMissing === true
+        record.barcodeMissing = record.barcodeMissing === true
+        record.issueSummary = ''
+        record.hasIssue = false
+        record.issueTypes = []
+        record._lastAcceptedProcessCode = record.processCode
+        record._lastAcceptedBarcode = record.barcode
+        record._lastAcceptedBarcodeImage = record.barcodeImage
+        this.updateIssueFlags(record)
+        return record
+      },
     updateIssueFlags(record) {
       if (!record) return
       const issues = []
@@ -450,7 +460,11 @@ export default {
       record.hoursMissing = record.hours === null || record.hours === undefined || record.hours === '' || Number.isNaN(record.hours)
       if (record.hoursMissing) issues.push('单件工时')
 
-      const hasProcessCode = this.hasText(record.processCode)
+      const normalizedCode = this.normalizeProcessCode(record.processCode)
+      if (normalizedCode !== record.processCode) {
+        record.processCode = normalizedCode
+      }
+      const hasProcessCode = this.isValidProcessCode(normalizedCode)
       const codeMissingFlag = record.serverCodeMissing === true || !hasProcessCode
       if (!codeMissingFlag) {
         record.serverCodeMissing = false
@@ -782,7 +796,7 @@ export default {
     async rememberProcessCode(record) {
       if (!record) return false
       const name = record.processName != null ? String(record.processName).trim() : ''
-      const code = record.processCode != null ? String(record.processCode).trim() : ''
+      const code = this.normalizeProcessCode(record.processCode)
       if (!name || !code) return false
       const key = `${name}|||${code}`
       if (this.rememberedPairs[key]) {
@@ -795,9 +809,12 @@ export default {
         return true
       }
       let headers
-      try { headers = this.requireUserHeaders() }
-      catch (err) { return false }
-      const previousCode = record._lastAcceptedProcessCode != null ? String(record._lastAcceptedProcessCode).trim() : ''
+      try {
+        headers = this.requireUserHeaders()
+      } catch (err) {
+        return false
+      }
+      const previousCode = this.normalizeProcessCode(record._lastAcceptedProcessCode)
       const previousBarcode = record._lastAcceptedBarcode || ''
       const previousImage = record._lastAcceptedBarcodeImage || ''
       try {
@@ -848,7 +865,7 @@ export default {
           for (const item of res.data) {
             if (!item || !item.name || !item.code) continue
             const name = String(item.name).trim()
-            const code = String(item.code).trim()
+            const code = this.normalizeProcessCode(item.code)
             if (!name || !code) continue
             map[name] = code
           }
@@ -868,7 +885,8 @@ export default {
     handleProcessCodeTyping(record) {
       if (!record) return
       const value = record.processCode != null ? String(record.processCode) : ''
-      const hasValue = this.hasText(value)
+      const normalized = this.normalizeProcessCode(value)
+      const hasValue = normalized !== ''
       record.serverCodeMissing = !hasValue
       record.codeMissing = !hasValue
       if (!hasValue) {
@@ -880,8 +898,9 @@ export default {
     async handleProcessCodeBlur(record) {
       if (!record) return
       const value = record.processCode != null ? String(record.processCode).trim() : ''
-      record.processCode = value
-      if (!value) {
+      const normalized = this.normalizeProcessCode(value)
+      record.processCode = normalized
+      if (!normalized) {
         record.serverCodeMissing = true
         record.codeMissing = true
         record.barcode = ''
@@ -923,50 +942,55 @@ export default {
       await this.updateProcess(record)
       await this.autoSaveRecord(record)
     },
-    async updateProcess(r, cacheReady = false, allowFetch = true, fetchBarcodeImage = true) {
-      if (!cacheReady) await this.ensureProcessCache()
-      const rawName = r.processName || ''
-      const name = rawName.trim()
-      const existingCode = r.processCode != null ? String(r.processCode).trim() : ''
-      let shouldRemember = false
-      if (!name) {
-        r.processCode = ''
-        r.serverCodeMissing = false
-        r.codeMissing = true
+      async updateProcess(r, cacheReady = false, allowFetch = true, fetchBarcodeImage = true) {
+        if (!cacheReady) await this.ensureProcessCache()
+        const rawName = r.processName || ''
+        const name = rawName.trim()
+        const existingCode = r.processCode != null ? String(r.processCode).trim() : ''
+        let shouldRemember = false
+        if (!name) {
+          r.processCode = ''
+          r.serverCodeMissing = false
+          r.codeMissing = true
+          await this.updateBarcode(r, fetchBarcodeImage)
+          this.updateIssueFlags(r)
+          return
+        }
+        let code = this.normalizeProcessCode(this.processCache[name])
+        if (!code && allowFetch) {
+          try {
+            const res = await axios.get(`/api/processcodes/name/${encodeURIComponent(name)}`)
+            if (res.data && res.data.code) {
+              const normalized = this.normalizeProcessCode(res.data.code)
+              if (normalized) {
+                code = normalized
+                this.$set(this.processCache, name, normalized)
+              }
+            }
+          } catch (e) { /* ignore */ }
+        }
+        const manualCode = this.normalizeProcessCode(existingCode)
+        if (code) {
+          r.processCode = code
+          r.serverCodeMissing = false
+        } else if (manualCode) {
+          r.processCode = manualCode
+          r.serverCodeMissing = false
+          if (!this.processCache[name] || this.processCache[name] !== manualCode) {
+            this.$set(this.processCache, name, manualCode)
+          }
+          shouldRemember = true
+        } else {
+          r.processCode = ''
+          r.serverCodeMissing = true
+        }
+        r.codeMissing = !this.isValidProcessCode(r.processCode)
         await this.updateBarcode(r, fetchBarcodeImage)
         this.updateIssueFlags(r)
-        return
-      }
-      let code = this.processCache[name]
-      if (!code && allowFetch) {
-        try {
-          const res = await axios.get(`/api/processcodes/name/${encodeURIComponent(name)}`)
-          if (res.data && res.data.code) {
-            code = String(res.data.code).trim()
-            if (code) this.$set(this.processCache, name, code)
-          }
-        } catch (e) { /* ignore */ }
-      }
-      const manualCode = this.hasText(existingCode) ? existingCode : ''
-      if (code) {
-        r.processCode = code
-        r.serverCodeMissing = false
-      } else if (manualCode) {
-        r.processCode = manualCode
-        r.serverCodeMissing = false
-        if (!this.processCache[name]) this.$set(this.processCache, name, manualCode)
-        shouldRemember = true
-      } else {
-        r.processCode = ''
-        r.serverCodeMissing = true
-      }
-      r.codeMissing = !this.hasText(r.processCode)
-      await this.updateBarcode(r, fetchBarcodeImage)
-      this.updateIssueFlags(r)
-      if (shouldRemember && !r.codeMissing) {
-        await this.rememberProcessCode(r)
-      }
-    },
+        if (shouldRemember && !r.codeMissing) {
+          await this.rememberProcessCode(r)
+        }
+      },
     checkHours(r) {
       r.hoursMissing = r.hours == null || r.hours === ''
       this.updateIssueFlags(r)
@@ -1155,8 +1179,14 @@ export default {
             if (!key) return
             const value = data[key]
             if (value == null) return
-            const code = String(value).trim()
-            if (code) this.$set(this.processCache, key, code)
+            const code = this.normalizeProcessCode(value)
+            if (code) {
+              this.$set(this.processCache, key, code)
+            } else if (this.$delete) {
+              this.$delete(this.processCache, key)
+            } else {
+              delete this.processCache[key]
+            }
           })
         } catch (error) {
           console.error('批量加载工序失败', error)
@@ -1166,8 +1196,13 @@ export default {
       await Promise.all(tasks)
     },
     async updateBarcode(r, fetchImage = true) {
-      if (r.drawingNumber && r.notificationNumber && r.processCode) {
-        const bar = `${r.drawingNumber}-${r.notificationNumber}-${r.processCode}`
+      const normalizedCode = this.normalizeProcessCode(r.processCode)
+      if (normalizedCode !== r.processCode) {
+        r.processCode = normalizedCode
+      }
+      const canUseCode = normalizedCode && r.serverCodeMissing !== true
+      if (r.drawingNumber && r.notificationNumber && canUseCode) {
+        const bar = `${r.drawingNumber}-${r.notificationNumber}-${normalizedCode}`
         const clean = this.sanitize(bar)
         r.barcode = clean
         if (!clean) { r.barcodeImage = ''; return }
@@ -1283,21 +1318,21 @@ export default {
     },
     getBulkConfig(type) {
       switch (type) {
-        case '工序代码':
-          return {
-            prompt: '请输入工序代码（将应用到当前筛选的所有记录）',
-            prepare(input) {
-              const value = String(input || '').trim()
-              if (!value) {
-                alert('请输入有效的工序代码')
-                return undefined
-              }
-              return value
-            },
-            apply(record, value) {
-              record.processCode = value
-              record.serverCodeMissing = false
-              record.codeMissing = false
+          case '工序代码':
+            return {
+              prompt: '请输入工序代码（将应用到当前筛选的所有记录）',
+              prepare(input) {
+                const normalized = this.normalizeProcessCode(input)
+                if (!normalized) {
+                  alert('请输入有效的工序代码（不可为空或为0）')
+                  return undefined
+                }
+                return normalized
+              },
+              apply(record, value) {
+                record.processCode = value
+                record.serverCodeMissing = false
+                record.codeMissing = false
               return this.updateBarcode(record)
             }
           }
@@ -1434,17 +1469,17 @@ export default {
             break
           }
           case '工序代码': {
-            const code = item.processCode != null ? String(item.processCode).trim() : ''
+            const code = this.normalizeProcessCode(item.processCode)
             record.processCode = code
-            record.serverCodeMissing = !this.hasText(code)
-            record.codeMissing = !this.hasText(code)
-            if (!this.hasText(code)) {
+            record.serverCodeMissing = !code
+            record.codeMissing = !code
+            if (!code) {
               record.barcode = ''
               record.barcodeImage = ''
               this.updateIssueFlags(record)
             } else {
               const name = record.processName != null ? String(record.processName).trim() : ''
-              if (name && !this.processCache[name]) this.$set(this.processCache, name, code)
+              if (name && (!this.processCache[name] || this.processCache[name] !== code)) this.$set(this.processCache, name, code)
               const previousBarcode = record.barcode
               const previousImage = record.barcodeImage
               await this.updateBarcode(record)

--- a/frontend/src/components/WorkerManager.vue
+++ b/frontend/src/components/WorkerManager.vue
@@ -31,15 +31,23 @@
       </tbody>
     </table>
     <!-- 新增人员模态框 -->
-    <div class="modal fade" tabindex="-1" ref="addModal">
-      <div class="modal-dialog modal-dialog-centered">
+    <div
+      class="modal fade show"
+      tabindex="-1"
+      role="dialog"
+      v-if="showAddModal"
+      style="display: block"
+      aria-modal="true"
+      @click.self="closeModal"
+    >
+      <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title">新增人员</h5>
             <button type="button" class="btn-close" @click="closeModal"></button>
           </div>
           <div class="modal-body">
-            <div class="mb-2"><input class="form-control form-control-sm" v-model="newWorker.code" placeholder="工号" /></div>
+            <div class="mb-2"><input class="form-control form-control-sm" v-model="newWorker.code" placeholder="工号" ref="codeInput" /></div>
             <div class="mb-2"><input class="form-control form-control-sm" v-model="newWorker.name" placeholder="姓名" /></div>
             <div class="mb-2"><input class="form-control form-control-sm" v-model="newWorker.workshop" placeholder="车间" /></div>
             <div class="mb-2"><input class="form-control form-control-sm" v-model="newWorker.team" placeholder="班组" /></div>
@@ -53,6 +61,7 @@
         </div>
       </div>
     </div>
+    <div v-if="showAddModal" class="modal-backdrop fade show"></div>
   </section>
 </template>
 
@@ -64,7 +73,7 @@ export default {
       workers: [],
       search: '',
       newWorker: { code: '', name: '', workshop: '', team: '', entryDate: '', leaveDate: '' },
-      modal: null
+      showAddModal: false
     }
   },
   computed: {
@@ -75,21 +84,38 @@ export default {
   watch: {
     search(val) {
       this.fetchWorkers(val)
+    },
+    showAddModal(val) {
+      if (typeof document !== 'undefined' && document.body) {
+        if (val) {
+          document.body.classList.add('modal-open')
+        } else {
+          this.$nextTick(() => {
+            const remaining = document.querySelectorAll('.modal.fade.show')
+            if (!remaining.length) {
+              document.body.classList.remove('modal-open')
+            }
+          })
+        }
+      }
     }
   },
   created() {
     this.fetchWorkers('')
   },
-  mounted() {
-    this.modal = new window.bootstrap.Modal(this.$refs.addModal)
-  },
   methods: {
     openModal() {
       this.newWorker = { code: '', name: '', workshop: '', team: '', entryDate: '', leaveDate: '' }
-      this.modal.show()
+      this.showAddModal = true
+      this.$nextTick(() => {
+        const input = this.$refs.codeInput
+        if (input && typeof input.focus === 'function') {
+          input.focus()
+        }
+      })
     },
     closeModal() {
-      this.modal.hide()
+      this.showAddModal = false
     },
     async fetchWorkers(term) {
       const url = term
@@ -110,6 +136,16 @@ export default {
     async deleteWorker(id) {
       await axios.delete(`/api/workers/${id}`)
       this.fetchWorkers(this.search)
+    }
+  },
+  beforeUnmount() {
+    if (typeof document !== 'undefined' && document.body) {
+      this.$nextTick(() => {
+        const remaining = document.querySelectorAll('.modal.fade.show')
+        if (!remaining.length) {
+          document.body.classList.remove('modal-open')
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure the upload parse endpoint always returns the persisted records
- stop bypassing persistence during upload parsing and keep preview deletions in sync with the backend
- delete zero-process rows through the API so database state stays consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f81ff8b53c832c9ba99b39b89ab6d5